### PR TITLE
Outline state boundary on hover instead of filling colour

### DIFF
--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -139,11 +139,13 @@ function ChoroplethMap(props) {
           .attr('pointer-events', 'all')
           .on('mouseover', (d) => {
             handleMouseover(d.properties.ST_NM);
-            d3.select(d3.event.target).attr('fill', '#424242');
+            const target = d3.event.target;
+            d3.select(target.parentNode.appendChild(target)).attr('stroke', '#424242').attr('stroke-width', 2)
           })
           .on('mouseout', (d) => {
             const n = unemployment.get(d.properties.ST_NM.toLowerCase());
-            d3.select(d3.event.target).attr('fill', d3.interpolateReds(d.confirmed = (n>0)*0.05 + n/statistic.maxConfirmed*0.8));
+            const target = d3.event.target;
+            d3.select(target).attr('fill', d3.interpolateReds(d.confirmed = (n>0)*0.05 + n/statistic.maxConfirmed*0.8)).attr('stroke', 'None');
           })
           .style('cursor', 'pointer')
           .append('title')


### PR DESCRIPTION
This seems like a better design to me, since it doesn't conceal colour information. 

<img width="402" alt="Screen Shot 2020-03-24 at 4 23 46 AM" src="https://user-images.githubusercontent.com/17938322/77378540-47276c80-6d87-11ea-9924-940a68de7861.png">
