### PR TITLE
Link to the updated github page

### DIFF
--- a/src/components/summary.js
+++ b/src/components/summary.js
@@ -46,7 +46,7 @@ function Summary(props) {
           <h5>We stand with everyone fighting on the frontlines</h5>
         </div>
         <div className="link">
-          <a href="https://github.com/covid19india">covid19india.org</a>
+          <a href="https://github.com/covid19india-react ">covid19india.org</a>
         </div>
       </div>
 


### PR DESCRIPTION
Old webpage ponts to "github.com/covid19india", changing it to "github.com/covid19india-react"