### PR TITLE
Fix links like https://www.covid19india.org/faqs

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "start": "PORT=3001 react-scripts start css-watch",
-    "build": "react-scripts build",
+    "build": "react-scripts build && cp build/index.html build/404.html",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "css-build": "node-sass --omit-source-map-url sass/custom.scss src/App.css",


### PR DESCRIPTION
Fixes covid19india/covid19india-react#65

We are copying index.html to 404.html so that GH pages takes 404.html (index.html) for all routes other than '/'

https://github.com/facebook/create-react-app/issues/1765#issuecomment-443598257