### PR TITLE
Fix the state-wise confirmed cases count (table)

### DIFF
--- a/src/components/row.js
+++ b/src/components/row.js
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from 'react';
 import * as Icon from 'react-feather';
 
-function Row(props) {
+const Row = props => {
   const [state, setState] = useState(props.state);
 
   useEffect(()=>{
@@ -12,7 +12,7 @@ function Row(props) {
     <tr className={props.total ? 'is-total' : ''}>
       <td style={{fontWeight: 600}}>{state.state}</td>
       <td>
-        {parseInt(state.confirmed)===0 ? '-' : state.active}
+        {parseInt(state.confirmed)===0 ? '-' : state.confirmed}
         <span className="deltas" style={{color: '#ff073a'}}>
           {!state.delta.confirmed==0 && <Icon.ArrowUp/>}
           {state.delta.confirmed > 0 ? `${state.delta.confirmed}` : ''}
@@ -41,6 +41,6 @@ function Row(props) {
       </td>
     </tr>
   );
-}
+};
 
 export default Row;


### PR DESCRIPTION
Simple change to fix the confirmed count for each state.

|Previous|Update|
|-|-|
|<img width="350" alt="Screen Shot 2020-03-26 at 6 55 30 AM" src="https://user-images.githubusercontent.com/7826197/77600767-d8851300-6f2e-11ea-84d6-1f2538d565a0.png">|<img width="350" alt="Screen Shot 2020-03-26 at 6 54 10 AM" src="https://user-images.githubusercontent.com/7826197/77600800-ed61a680-6f2e-11ea-8d2e-f09337472467.png">|


