### PR TITLE
Added support for district wise data below MAP, so that hover on map changes data below

### DIFF
--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -57,6 +57,7 @@ function ChoroplethMap(props) {
       if (state.state.toLowerCase()===name.toLowerCase()) {
         setState(state);
         setIndex(index);
+        props.onHighlightState(state,index);
       }
     });
   };
@@ -213,7 +214,6 @@ function ChoroplethMap(props) {
         </div>
 
       </div>
-
     </div>
   );
 }

--- a/src/components/districtrow.js
+++ b/src/components/districtrow.js
@@ -1,0 +1,22 @@
+import React, { useState, useEffect } from "react";
+import * as Icon from "react-feather";
+
+function DistrictRow(props) {
+  const [districtData, setDistrictData] = useState(props.district);
+
+  useEffect(() => {
+    setDistrictData(props.district);
+  }, [props.district]);
+
+  return (
+    <tr className={props.total ? "is-total" : ""}>
+      <td style={{ fontWeight: 600 }}>{districtData[0]}</td>
+      <td>{parseInt(districtData[1].confirmed) === 0 ? "-" : districtData[1].confirmed}</td>
+      <td style={{ color: parseInt(districtData[1].active) === 0 ? "#B5B5B5" : "inherit" }}>{parseInt(districtData[1].active) == 0 ? "-" : districtData[1].active}</td>
+      <td style={{ color: parseInt(districtData[1].recovered) === 0 ? "#B5B5B5" : "inherit" }}>{parseInt(districtData[1].recovered) === 0 ? "-" : districtData[1].recovered}</td>
+      <td style={{ color: parseInt(districtData[1].deaths) === 0 ? "#B5B5B5" : "inherit" }}>{parseInt(districtData[1].deaths) === 0 ? "-" : districtData[1].deaths}</td>
+    </tr>
+  );
+}
+
+export default DistrictRow;

--- a/src/components/districtwisetable.js
+++ b/src/components/districtwisetable.js
@@ -1,0 +1,94 @@
+import React, { useState, useEffect } from "react";
+import * as Icon from "react-feather";
+
+import Row from "./row";
+import DistrictRow from "./districtrow";
+
+function DistrictWiseTable(props) {
+  const [states, setStates] = useState(props.state);
+  const [state, setState] = useState(props.states[1]);
+  const [district, setDistrict] = useState(props.district);
+  const [index, setIndex] = useState(1);
+  
+  useEffect(() => {
+    setStates(props.states);
+    if (props.states !== undefined && props.states.length > 1) {
+      setState(props.states[1].state);
+    }
+  }, [props.states]);
+
+  useEffect(() => {
+    if (props.stateHighlighted !== undefined) {
+      setState(props.stateHighlighted.state);
+      setIndex(props.stateHighlighted.index);
+    }
+  }, [props.stateHighlighted]);
+
+  useEffect(() => {
+    setDistrict(props.district);
+  }, [props.district]);
+
+  const parseDistrict = () => {
+    const dist = props.district;
+    const distArr = [];
+    if (state !== undefined && dist[state] !== undefined && dist[state]["districtData"] !== undefined) {
+      Object.keys(dist[state]["districtData"]).forEach(function (key) {
+        distArr.push([key, dist[state]["districtData"][key]]);
+      });
+    }
+    return distArr;
+  };
+
+  return (
+    <table className="table fadeInUp" style={{ animationDelay: "1s" }}>
+      <h5 className="affected-count">
+        {" "}
+        {state !== undefined ? state : ""} / {parseDistrict().length} districts Affected
+      </h5>
+      <thead>
+        <tr>
+          <th className="state-heading">
+            <div className="heading-content">
+              <abbr title="State">District / City</abbr>
+            </div>
+          </th>
+          <th>
+            <div className="heading-content">
+              <abbr className={`${window.innerWidth <= 769 ? "is-cherry" : ""}`} title="Confirmed">
+                {window.innerWidth <= 769 ? (window.innerWidth <= 375 ? "C" : "Cnfmd") : "Confirmed"}
+              </abbr>
+            </div>
+          </th>
+          <th>
+            <div className="heading-content">
+              <abbr className={`${window.innerWidth <= 769 ? "is-blue" : ""}`} title="Active">
+                {window.innerWidth <= 769 ? (window.innerWidth <= 375 ? "A" : "Actv") : "Active"}
+              </abbr>
+            </div>
+          </th>
+          <th>
+            <div className="heading-content">
+              <abbr className={`${window.innerWidth <= 769 ? "is-green" : ""}`} title="Recovered">
+                {window.innerWidth <= 769 ? (window.innerWidth <= 375 ? "R" : "Rcvrd") : "Recovered"}
+              </abbr>
+            </div>
+          </th>
+          <th>
+            <div className="heading-content">
+              <abbr className={`${window.innerWidth <= 769 ? "is-gray" : ""}`} title="Deaths">
+                {window.innerWidth <= 769 ? (window.innerWidth <= 375 ? "D" : "Dcsd") : "Deaths"}
+              </abbr>
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {parseDistrict().map((district, index) => {
+          return <DistrictRow key={index} index={index} district={district} total={false} onHighlightState={props.onHighlightState} />;
+        })}
+      </tbody>
+    </table>
+  );
+}
+
+export default DistrictWiseTable;

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -9,6 +9,7 @@ import ChoroplethMap from './choropleth';
 import TimeSeries from './timeseries';
 import Minigraph from './minigraph';
 import Banner from './banner';
+import DistrictWiseTable from './districtwisetable';
 
 function Home(props) {
   const [states, setStates] = useState([]);
@@ -20,11 +21,13 @@ function Home(props) {
   const [timeseriesMode, setTimeseriesMode] = useState(true);
   const [rawData, setRawData] = useState([]);
   const [stateHighlighted, setStateHighlighted] = useState(undefined);
+  const [districtData, setDistrictData] = useState([]);
 
   useEffect(()=> {
     if (fetched===false) {
       getStates();
       getRawData();
+      getDistrictWiseData();
     }
   }, [fetched]);
 
@@ -51,6 +54,17 @@ function Home(props) {
         console.log(err);
       });
   };
+
+  const getDistrictWiseData = () => {
+    axios.get('https://api.covid19india.org/state_district_wise.json')
+      .then((response) => {
+        console.log(response.data);
+        setDistrictData(response.data);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }
 
   const getConfirmedCases = () => {
     let confirmed = 0;
@@ -114,8 +128,11 @@ function Home(props) {
 
       <div className="home-right">
 
-        <ChoroplethMap states={states} stateHighlighted={stateHighlighted} />
+        <ChoroplethMap states={states} stateHighlighted={stateHighlighted} onHighlightState={onHighlightState} />
 
+        <div className="timeseries-header fadeInUp" style={{ animationDelay: '1.5s' }}>
+          <DistrictWiseTable states={states} district={districtData} stateHighlighted={stateHighlighted !== undefined ? stateHighlighted.state : stateHighlighted} />
+        </div>
         <div className="timeseries-header fadeInUp" style={{animationDelay: '1.5s'}}>
           <h1>Spread Trends</h1>
           <div className="tabs">

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -18,10 +18,12 @@ function Home(props) {
   const [timeseries, setTimeseries] = useState([]);
   const [deltas, setDeltas] = useState([]);
   const [timeseriesMode, setTimeseriesMode] = useState(true);
+  const [rawData, setRawData] = useState([]);
 
   useEffect(()=> {
     if (fetched===false) {
       getStates();
+      getRawData();
     }
   }, [fetched]);
 
@@ -38,6 +40,33 @@ function Home(props) {
           console.log(err);
         });
   };
+
+  const getRawData = () => {
+    axios.get('https://api.covid19india.org/raw_data.json')
+      .then((response) => {
+        setRawData(response.data.raw_data);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  const getConfirmedCases = () => {
+    let confirmed = 0;
+    states.map((state, index) => {
+      if (index !== 0) {
+        confirmed += parseInt(state.confirmed);
+      }
+    });
+    return confirmed;
+  }
+
+  const getIndianPrecentage = () => {
+    const confirmed = getConfirmedCases();
+    const indianCount = rawData.filter(d => d.nationality === "India").length;
+    const indiaPercent = indianCount / confirmed * 100;
+    return Math.round(indiaPercent);
+  }
 
   return (
     <div className="Home">
@@ -58,7 +87,13 @@ function Home(props) {
 
         <Level data={states} deltas={deltas}/>
         <Minigraph timeseries={timeseries} animate={true}/>
-
+        <div className="header fadeInUp" style={{ animationDelay: '0.5s' }}>
+          <div className="header-mid">
+            <div className="titles">
+              <h6>Of the {getConfirmedCases()} confirmed cases , {getIndianPrecentage()} % are Indian National, rest {100 - getIndianPrecentage()} % is being verified.</h6>
+            </div>
+          </div>
+        </div>
         <Table states={states} summary={false}/>
 
       </div>


### PR DESCRIPTION
Added support for district wise data below MAP, so that hover on map changes data below and also hover over the table 

Hover over app in addition to changing stats on left side, also changes stats below thereby avoiding the need to search for the state in the table and expanding

![image](https://user-images.githubusercontent.com/26976558/77640811-03985280-6f81-11ea-8b90-305580ca332b.png)
