### PR TITLE
Dynamically rerender trend charts change in window size [WIP]

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,9 +1,9 @@
 @font-face {
   font-family: 'Archia';
   src: url('fonts/Archia/archia-thin-webfont.eot');
-  src: url('fonts/Archia/archia-thin-webfont.eot?#iefix') format('embedded-opentype'),       
-  url('fonts/Archia/archia-thin-webfont.woff2') format('woff2'),       
-  url('fonts/Archia/archia-thin-webfont.woff') format('woff'),       
+  src: url('fonts/Archia/archia-thin-webfont.eot?#iefix') format('embedded-opentype'),
+  url('fonts/Archia/archia-thin-webfont.woff2') format('woff2'),
+  url('fonts/Archia/archia-thin-webfont.woff') format('woff'),
   url('fonts/Archia/archia-thin-webfont.ttf') format('truetype');
   font-weight: 100;
   font-style: normal;
@@ -12,9 +12,9 @@
 @font-face {
   font-family: 'Archia';
   src: url('fonts/Archia/archia-light-webfont.eot');
-  src: url('fonts/Archia/archia-light-webfont.eot?#iefix') format('embedded-opentype'),       
-  url('fonts/Archia/archia-light-webfont.woff2') format('woff2'),       
-  url('fonts/Archia/archia-light-webfont.woff') format('woff'),       
+  src: url('fonts/Archia/archia-light-webfont.eot?#iefix') format('embedded-opentype'),
+  url('fonts/Archia/archia-light-webfont.woff2') format('woff2'),
+  url('fonts/Archia/archia-light-webfont.woff') format('woff'),
   url('fonts/Archia/archia-light-webfont.ttf') format('truetype');
   font-weight: 200;
   font-style: normal;
@@ -23,9 +23,9 @@
 @font-face {
   font-family: 'Archia';
   src: url('fonts/Archia/archia-regular-webfont.eot');
-  src: url('fonts/Archia/archia-regular-webfont.eot?#iefix') format('embedded-opentype'),       
-  url('fonts/Archia/archia-regular-webfont.woff2') format('woff2'),       
-  url('fonts/Archia/archia-regular-webfont.woff') format('woff'),       
+  src: url('fonts/Archia/archia-regular-webfont.eot?#iefix') format('embedded-opentype'),
+  url('fonts/Archia/archia-regular-webfont.woff2') format('woff2'),
+  url('fonts/Archia/archia-regular-webfont.woff') format('woff'),
   url('fonts/Archia/archia-regular-webfont.ttf') format('truetype');
   font-weight: 300;
   font-style: normal;
@@ -34,9 +34,9 @@
 @font-face {
   font-family: 'Archia';
   src: url('fonts/Archia/archia-medium-webfont.eot');
-  src: url('fonts/Archia/archia-medium-webfont.eot?#iefix') format('embedded-opentype'),       
-  url('fonts/Archia/archia-medium-webfont.woff2') format('woff2'),       
-  url('fonts/Archia/archia-medium-webfont.woff') format('woff'),       
+  src: url('fonts/Archia/archia-medium-webfont.eot?#iefix') format('embedded-opentype'),
+  url('fonts/Archia/archia-medium-webfont.woff2') format('woff2'),
+  url('fonts/Archia/archia-medium-webfont.woff') format('woff'),
   url('fonts/Archia/archia-medium-webfont.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
@@ -45,9 +45,9 @@
 @font-face {
   font-family: 'Archia';
   src: url('fonts/Archia/archia-semibold-webfont.eot');
-  src: url('fonts/Archia/archia-semibold-webfont.eot?#iefix') format('embedded-opentype'),       
-  url('fonts/Archia/archia-semibold-webfont.woff2') format('woff2'),       
-  url('fonts/Archia/archia-semibold-webfont.woff') format('woff'),       
+  src: url('fonts/Archia/archia-semibold-webfont.eot?#iefix') format('embedded-opentype'),
+  url('fonts/Archia/archia-semibold-webfont.woff2') format('woff2'),
+  url('fonts/Archia/archia-semibold-webfont.woff') format('woff'),
   url('fonts/Archia/archia-semibold-webfont.ttf') format('truetype');
   font-weight: 600;
   font-style: normal;
@@ -56,9 +56,9 @@
 @font-face {
   font-family: 'Archia';
   src: url('fonts/Archia/archia-bold-webfont.eot');
-  src: url('fonts/Archia/archia-bold-webfont.eot?#iefix') format('embedded-opentype'),       
-  url('fonts/Archia/archia-bold-webfont.woff2') format('woff2'),       
-  url('fonts/Archia/archia-bold-webfont.woff') format('woff'),       
+  src: url('fonts/Archia/archia-bold-webfont.eot?#iefix') format('embedded-opentype'),
+  url('fonts/Archia/archia-bold-webfont.woff2') format('woff2'),
+  url('fonts/Archia/archia-bold-webfont.woff') format('woff'),
   url('fonts/Archia/archia-bold-webfont.ttf') format('truetype');
   font-weight: 900;
   font-style: normal;
@@ -169,28 +169,28 @@ h3 {
   font-family: 'archia';
   font-size: 14px !important;
   font-weight: 400;
-  text-transform: uppercase; 
+  text-transform: uppercase;
 }
 
 h4 {
   font-family: 'archia';
   font-size: 13px !important;
   font-weight: 900;
-  text-transform: uppercase; 
+  text-transform: uppercase;
 }
 
 h5 {
   font-family: 'archia';
   font-size: 12px !important;
   font-weight: 900;
-  text-transform: uppercase; 
+  text-transform: uppercase;
 }
 
 h6 {
   font-family: 'archia';
   font-size: 11px !important;
   font-weight: 600;
-  text-transform: uppercase; 
+  text-transform: uppercase;
 }
 
 .Home {
@@ -303,7 +303,7 @@ a.button {
   color: $blue-mid;
   cursor: pointer;
   font-weight: 900;
-  border-radius: 5px; 
+  border-radius: 5px;
   transition: background 0.2s ease-in-out;
   margin-bottom: 0.5rem;
   margin-top: 0.25rem;
@@ -369,7 +369,7 @@ a.button {
     }
     &:first-child {
       margin-left: 0.5rem;
-    } 
+    }
     &:last-child {
       margin-right: 0.5rem;
     }
@@ -695,11 +695,13 @@ table {
     margin-bottom: 1rem;
     height: 10rem;
     svg {
+      width: 100%;
+      height: 100%;
       .domain, .tick, line {
         stroke: $cherry;
         stroke-width: 2;
       }
-      text {  
+      text {
         font-family: 'archia';
         text-transform: uppercase;
         color: $cherry-mid;
@@ -935,7 +937,7 @@ footer {
   }
 }
 
-/* For the iPhone X folks OMG WHY ARE YOUR SCREENS SO NARROW T_T*/ 
+/* For the iPhone X folks OMG WHY ARE YOUR SCREENS SO NARROW T_T*/
 @media (max-width: 375px) {
   .timeseries-mode {
     display: block !important;

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -71,7 +71,7 @@ function ChoroplethMap(props) {
         const n = Math.floor(generatedLabels[i]);
         return `${n}+`;
       } else {
-        const n1 = Math.floor(generatedLabels[i]);
+        const n1 = 1 + Math.floor(generatedLabels[i]);
         const n2 = Math.floor(generatedLabels[i+1]);
         return `${n1} - ${n2}`;
       }

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -119,7 +119,8 @@ function ChoroplethMap(props) {
           .enter().append('path')
           .attr('fill', function(d) {
             const n = unemployment.get(d.properties.ST_NM.toLowerCase());
-            return d3.interpolateReds(d.confirmed = (n>0)*0.05 + n/statistic.maxConfirmed*maxInterpolation);
+            const color = (n == 0) ? '#ffffff' : d3.interpolateReds(maxInterpolation * n/statistic.maxConfirmed);
+            return color
           })
           .attr('d', path)
           .attr('pointer-events', 'all')
@@ -131,7 +132,8 @@ function ChoroplethMap(props) {
           .on('mouseleave', (d) => {
             const n = unemployment.get(d.properties.ST_NM.toLowerCase());
             const target = d3.event.target;
-            d3.select(target).attr('fill', d3.interpolateReds(d.confirmed = (n>0)*0.05 + n/statistic.maxConfirmed*maxInterpolation)).attr('stroke', 'None');
+            const color = (n == 0) ? '#ffffff' : d3.interpolateReds(maxInterpolation * n/statistic.maxConfirmed);
+            d3.select(target).attr('fill', color).attr('stroke', 'None');
           })
           .style('cursor', 'pointer')
           .append('title')

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -64,7 +64,7 @@ function TimeSeries(props) {
     resizeObserver.observe(el);
 
     const svg1 = d3.select(graphElement1.current);
-    const margin = {top: 20, right: 20, bottom: 10, left: 30};
+    const margin = {top: 20, right: 15, bottom: 10, left: 25};
     const pwidth = svg1.node().getBoundingClientRect().width;
     const pheight = svg1.node().getBoundingClientRect().height;
     const width = pwidth - margin.left - margin.right;
@@ -88,135 +88,63 @@ function TimeSeries(props) {
         .domain([0, timeseries.length])
         .range([margin.left,width]);
 
-    svg1.append('g')
-        .attr('transform', 'translate(0,' + height + ')')
-        .attr('class', 'axis')
-        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
-
-    svg2.append('g')
-        .attr('transform', 'translate(0,' + height + ')')
-        .attr('class', 'axis')
-        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
-
-    svg3.append('g')
-        .attr('transform', 'translate(0,' + height + ')')
-        .attr('class', 'axis')
-        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
-
-    svg4.append('g')
-        .attr('transform', 'translate(0,' + height + ')')
-        .attr('class', 'axis')
-        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
-
-    svg5.append('g')
-        .attr('transform', 'translate(0,' + height + ')')
-        .attr('class', 'axis')
-        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
-
-    svg6.append('g')
-        .attr('transform', 'translate(0,' + height + ')')
-        .attr('class', 'axis')
-        .call(d3.axisBottom(x));
-
-    const totalConfirmed = data[timeseries.length-1]['totalconfirmed'];
-    const totalRecovered = data[timeseries.length-1]['totalrecovered'];
-    const totalDeceased = data[timeseries.length-1]['totaldeceased'];
-
-    const y1 = d3.scaleLinear()
-        .domain([-totalConfirmed/10, totalConfirmed])
-        .range([height, margin.top]);
-
-    const y2 = d3.scaleLinear()
-        .domain([-totalRecovered/10, totalRecovered])
-        .range([height, margin.top]);
-
-    const y3 = d3.scaleLinear()
-        .domain([-totalDeceased/10, totalDeceased])
-        .range([height, margin.top]);
-
-    const maxDailyConfirmed = d3.max(data, function(d) { return +d['dailyconfirmed']; })
-    const maxDailyRecovered = d3.max(data, function(d) { return +d['dailyrecovered']; })
-    const maxDailyDeceased = d3.max(data, function(d) { return +d['dailydeceased']; })
-
-    const y4 = d3.scaleLinear()
-        .domain([-maxDailyConfirmed/10, maxDailyConfirmed])
-        .range([height, margin.top]);
-
-    const y5 = d3.scaleLinear()
-        .domain([-maxDailyRecovered/10, maxDailyRecovered])
-        .range([height, margin.top]);
-
-    const y6 = d3.scaleLinear()
-        .domain([-maxDailyDeceased/10, maxDailyDeceased])
-        .range([height, margin.top]);
-
-    /* Y-Axis */
-    svg1.append('g')
-        .attr('transform', `translate(${width}, ${0})`)
-        .attr('class', 'axis')
-        .call(d3.axisRight(y1).ticks(5).tickPadding(5));
-
-    svg2.append('g')
-        .attr('transform', `translate(${width}, ${0})`)
-        .attr('class', 'axis')
-        .call(d3.axisRight(mode ? y1 : y2).ticks(5).tickPadding(5));
-
-    svg3.append('g')
-        .attr('transform', `translate(${width}, ${0})`)
-        .attr('class', 'axis')
-        .call(d3.axisRight(mode ? y1 : y3).ticks(5).tickPadding(5));
-
-    svg4.append('g')
-        .attr('transform', `translate(${width}, ${0})`)
-        .attr('class', 'axis')
-        .call(d3.axisRight(mode ? y1 : y4).ticks(5).tickPadding(5));
-
-    svg5.append('g')
-        .attr('transform', `translate(${width}, ${0})`)
-        .attr('class', 'axis')
-        .call(d3.axisRight(mode ? y1 : y5).ticks(5).tickFormat((tick) => {
-          if (Math.floor(tick) !== tick) {
-            return;
-          }
-          return tick;
-        })
-        .tickPadding(5));
-
-    svg6.append('g')
-        .attr('transform', `translate(${width}, ${0})`)
-        .attr('class', 'axis')
-        .call(d3.axisRight(mode ? y1 : y6).ticks(5).tickFormat((tick) => {
-          if (Math.floor(tick) !== tick) {
-            return;
-          }
-          return tick;
-        })
-        .tickPadding(5));
-
-    /* Focus Circle */
-    // TODO: Vectorize rest of file as well
     const svgArray = [svg1, svg2, svg3, svg4, svg5, svg6];
+
+    /* X axis */
+    svgArray.forEach((s) => {
+      s.append('g')
+        .attr('transform', 'translate(0,' + height + ')')
+        .attr('class', 'axis')
+        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
+    });
+
     const dataTypes = ['totalconfirmed', 'totalrecovered', 'totaldeceased',
                        'dailyconfirmed', 'dailyrecovered', 'dailydeceased'];
-    const colors = ['#ff073a', '#28a745', '#6c757d', '#ff073a', '#28a745', '#6c757d'];
-    const yScales = [y1, y2, y3, y4, y5, y6];
 
-    var focus = svgArray.map(function(d, i) {
-                  const y = mode ? y1 : yScales[i];
-                  return d.append('g')
-                    .append('circle')
-                    .attr('fill', colors[i])
-                    .attr('stroke', colors[i])
-                    .attr('r', 5)
-                    .attr('cx', x(new Date(data[timeseries.length-1]['date'] + '2020')))
-                    .attr('cy', y(data[timeseries.length-1][dataTypes[i]]));
-                  });
+    const maxDataTypes = Array.from({ length: svgArray.length }, (_, i) => {
+      return d3.max(data, (d) => { return +d[dataTypes[i]]; })
+    })
+
+    console.log(maxDataTypes);
+    const yScales = maxDataTypes.map((d) => {
+      return d3.scaleLinear()
+              .domain([-d/10, d])
+              .range([height, margin.top]);
+    });
+
+    /* Y axis */
+    svgArray.forEach((s, i) => {
+      s.append('g')
+        .attr('transform', `translate(${width}, ${0})`)
+        .attr('class', 'axis')
+        .call(d3.axisRight(mode ? yScales[0] : yScales[i])
+          .ticks(5)
+          .tickPadding(5)
+          .tickFormat((tick) => {
+            if (Math.floor(tick) === tick) { return tick; }
+          })
+        );
+    });
+
+    /* Focus dots */
+    const colors = ['#ff073a', '#28a745', '#6c757d', '#ff073a', '#28a745', '#6c757d'];
+
+    var focus = svgArray.map((d, i) => {
+      const y = mode ? yScales[0] : yScales[i];
+      return d.append('g')
+        .append('circle')
+        .attr('fill', colors[i])
+        .attr('stroke', colors[i])
+        .attr('r', 4)
+        .attr('cx', x(new Date(data[timeseries.length-1]['date'] + '2020')))
+        .attr('cy', y(data[timeseries.length-1][dataTypes[i]]));
+    });
 
     function mouseout() {
       setDatapoint(data[timeseries.length - 1]);
       setIndex(timeseries.length - 1);
-      focus.forEach(function (d, i) {
-        const y = mode ? y1 : yScales[i];
+      focus.forEach((d, i) => {
+        const y = mode ? yScales[0] : yScales[i];
         d.attr('cx', x(new Date(data[timeseries.length-1]['date'] + '2020')))
          .attr('cy', y(data[timeseries.length-1][dataTypes[i]]));
       });
@@ -230,7 +158,7 @@ function TimeSeries(props) {
         setDatapoint(d);
         setIndex(i);
         focus.forEach(function (f, j) {
-          const y = mode ? y1 : yScales[j];
+          const y = mode ? yScales[0] : yScales[j];
           f.attr('cx', x(new Date(d['date'] + '2020')))
            .attr('cy', y(d[dataTypes[j]]));
         });
@@ -244,211 +172,43 @@ function TimeSeries(props) {
 
 
     /* Paths */
-    svg1.append('path')
+    svgArray.forEach((s, i) => {
+      s.append('path')
         .datum(data)
         .attr('fill', 'none')
-        .attr('stroke', '#ff073a99')
-        .attr('stroke-width', 5)
+        .attr('stroke', colors[i] + '99')
+        .attr('stroke-width', 3)
         .attr('cursor', 'pointer')
         .attr('d', d3.line()
             .x(function(d) {
               return x(new Date(d['date']+'2020'));
             })
             .y(function(d) {
-              return y1(d['totalconfirmed']);
+              if (mode) return yScales[0](d[dataTypes[i]]);
+              else return yScales[i](d[dataTypes[i]]);
             })
             .curve(d3.curveCardinal),
         );
+    });
 
-    svg1.selectAll('.dot')
+    /* Path Dots */
+    svgArray.forEach((s, i) => {
+      s.selectAll('.dot')
         .data(data)
         .enter()
         .append('circle')
-        .attr('fill', '#ff073a')
-        .attr('stroke', '#ff073a')
-        .attr('r', 3)
+        .attr('fill', colors[i])
+        .attr('stroke', colors[i])
+        .attr('r', 2)
         .attr('cursor', 'pointer')
         .attr('cx', function(d) {
           return x(new Date(d['date']+'2020'));
         })
         .attr('cy', function(d) {
-          return y1(d['totalconfirmed']);
+          if (mode) return yScales[0](d[dataTypes[i]]);
+          return yScales[i](d[dataTypes[i]]);
         });
-
-
-    svg2.append('path')
-        .datum(data)
-        .attr('fill', 'none')
-        .attr('stroke', '#28a74599')
-        .attr('stroke-width', 5)
-        .attr('cursor', 'pointer')
-        .attr('d', d3.line()
-            .x(function(d) {
-              return x(new Date(d['date']+'2020'));
-            })
-            .y(function(d) {
-              if (mode) return y1(d['totalrecovered']);
-              else return y2(d['totalrecovered']);
-            })
-            .curve(d3.curveCardinal),
-        );
-
-    svg2.selectAll('.dot')
-        .data(data)
-        .enter()
-        .append('circle')
-        .attr('fill', '#28a745')
-        .attr('stroke', '#28a745')
-        .attr('r', 3)
-        .attr('cursor', 'pointer')
-        .attr('cx', function(d) {
-          return x(new Date(d['date']+'2020'));
-        })
-        .attr('cy', function(d) {
-          if (mode) return y1(d['totalrecovered']);
-          return y2(d['totalrecovered']);
-        });
-
-
-    svg3.append('path')
-        .datum(data)
-        .attr('fill', 'none')
-        .attr('cursor', 'pointer')
-        .attr('stroke', '#6c757d99')
-        .attr('stroke-width', 5)
-        .attr('cursor', 'pointer')
-        .attr('cursor', 'pointer')
-        .attr('d', d3.line()
-            .x(function(d) {
-              return x(new Date(d['date']+'2020'));
-            })
-            .y(function(d) {
-              if (mode) return y1(d['totaldeceased']);
-              return y3(d['totaldeceased']);
-            })
-            .curve(d3.curveCardinal),
-        );
-
-    svg3.selectAll('.dot')
-        .data(data)
-        .enter()
-        .append('circle')
-        .attr('fill', '#6c757d')
-        .attr('stroke', '#6c757d')
-        .attr('r', 3)
-        .attr('cursor', 'pointer')
-        .attr('cx', function(d) {
-          return x(new Date(d['date']+'2020'));
-        })
-        .attr('cy', function(d) {
-          if (mode) return y1(d['totaldeceased']);
-          return y3(d['totaldeceased']);
-        });
-
-
-    /* Daily */
-    svg4.append('path')
-        .datum(data)
-        .attr('fill', 'none')
-        .attr('stroke', '#ff073a99')
-        .attr('stroke-width', 5)
-        .attr('cursor', 'pointer')
-        .attr('d', d3.line()
-            .x(function(d) {
-              return x(new Date(d['date']+'2020'));
-            })
-            .y(function(d) {
-              if (mode) return y1(d['dailyconfirmed']);
-              return y4(d['dailyconfirmed']);
-            })
-            .curve(d3.curveCardinal),
-        );
-
-    svg4.selectAll('.dot')
-        .data(data)
-        .enter()
-        .append('circle')
-        .attr('fill', '#ff073a')
-        .attr('stroke', '#ff073a')
-        .attr('r', 3)
-        .attr('cursor', 'pointer')
-        .attr('cx', function(d) {
-          return x(new Date(d['date']+'2020'));
-        })
-        .attr('cy', function(d) {
-          if (mode) return y1(d['dailyconfirmed']);
-          return y4(d['dailyconfirmed']);
-        });
-
-
-    svg5.append('path')
-        .datum(data)
-        .attr('fill', 'none')
-        .attr('stroke', '#28a74599')
-        .attr('stroke-width', 5)
-        .attr('cursor', 'pointer')
-        .attr('d', d3.line()
-            .x(function(d) {
-              return x(new Date(d['date']+'2020'));
-            })
-            .y(function(d) {
-              if (mode) return y1(d['dailyrecovered']);
-              return y5(d['dailyrecovered']);
-            })
-            .curve(d3.curveCardinal),
-        );
-
-    svg5.selectAll('.dot')
-        .data(data)
-        .enter()
-        .append('circle')
-        .attr('fill', '#28a745')
-        .attr('stroke', '#28a745')
-        .attr('r', 3)
-        .attr('cursor', 'pointer')
-        .attr('cx', function(d) {
-          return x(new Date(d['date']+'2020'));
-        })
-        .attr('cy', function(d) {
-          if (mode) return y1(d['dailyrecovered']);
-          return y5(d['dailyrecovered']);
-        });
-
-
-    svg6.append('path')
-        .datum(data)
-        .attr('fill', 'none')
-        .attr('cursor', 'pointer')
-        .attr('stroke', '#6c757d99')
-        .attr('stroke-width', 5)
-        .attr('cursor', 'pointer')
-        .attr('cursor', 'pointer')
-        .attr('d', d3.line()
-            .x(function(d) {
-              return x(new Date(d['date']+'2020'));
-            })
-            .y(function(d) {
-              if (mode) return y1(d['dailydeceased']);
-              return y6(d['dailydeceased']);
-            })
-            .curve(d3.curveCardinal),
-        );
-
-    svg6.selectAll('.dot')
-        .data(data)
-        .enter()
-        .append('circle')
-        .attr('fill', '#6c757d')
-        .attr('stroke', '#6c757d')
-        .attr('r', 3)
-        .attr('cursor', 'pointer')
-        .attr('cx', function(d) {
-          return x(new Date(d['date']+'2020'));
-        })
-        .attr('cy', function(d) {
-          if (mode) return y1(d['dailydeceased']);
-          return y6(d['dailydeceased']);
-        });
+    });
   };
 
   return (

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -39,6 +39,12 @@ function TimeSeries(props) {
     }
   }, [update]);
 
+  let resizeObserver = new ResizeObserver(() => {
+    if (timeseries.length>1) {
+      refreshGraphs(graphData);
+    }
+  });
+
   const refreshGraphs = () => {
     const graphs = [graphElement1, graphElement2, graphElement3, graphElement4, graphElement5, graphElement6];
     for (let i=0; i<=graphs.length; i++) {
@@ -54,10 +60,14 @@ function TimeSeries(props) {
     setDatapoint(timeseries[timeseries.length-1]);
     setIndex(timeseries.length-1);
 
+    var el = document.getElementById("123");
+    resizeObserver.observe(el);
     const svg1 = d3.select(graphElement1.current);
-    const margin = {top: 0, right: 20, bottom: 50, left: 20};
-    const width = 650 - margin.left - margin.right;
-    const height = 200 - margin.top - margin.bottom;
+    const margin = {top: 20, right: 20, bottom: 10, left: 20};
+    const pwidth = svg1.node().getBoundingClientRect().width;
+    const pheight = svg1.node().getBoundingClientRect().height;
+    const width = pwidth - margin.left - margin.right;
+    const height = pheight - margin.top - margin.bottom;
 
     const svg2 = d3.select(graphElement2.current);
     const svg3 = d3.select(graphElement3.current);
@@ -438,7 +448,7 @@ function TimeSeries(props) {
     <div className="TimeSeries-Parent fadeInUp" style={{animationDelay: '1.7s'}}>
       <div className="timeseries" style={{display: props.type===1 ? 'flex' : 'none'}}>
 
-        <div className="svg-parent">
+        <div className="svg-parent" id="123">
           <div className="stats">
             <h5>Confirmed {datapoint['date']}</h5>
             <div className="stats-bottom">
@@ -446,7 +456,7 @@ function TimeSeries(props) {
               <h6>{timeseries.length>0 && index!==0 ? timeseries[index]['totalconfirmed'] - timeseries[index-1]['totalconfirmed']>=0 ? '+'+(timeseries[index]['totalconfirmed'] - timeseries[index-1]['totalconfirmed']) : (timeseries[index]['totalconfirmed'] - timeseries[index-1]['totalconfirmed']) : ''}</h6>
             </div>
           </div>
-          <svg ref={graphElement1} width="650" height="200" viewBox="0 0 650 200" preserveAspectRatio="xMidYMid meet"/>
+          <svg ref={graphElement1}/>
         </div>
 
         <div className="svg-parent is-green">
@@ -457,7 +467,7 @@ function TimeSeries(props) {
               <h6>{timeseries.length>0 && index!==0 ? timeseries[index]['totalrecovered'] - timeseries[index-1]['totalrecovered']>=0 ? '+'+(timeseries[index]['totalrecovered'] - timeseries[index-1]['totalrecovered']) : (timeseries[index]['totalrecovered'] - timeseries[index-1]['totalrecovered']) : ''}</h6>
             </div>
           </div>
-          <svg ref={graphElement2} width="650" height="200" viewBox="0 0 650 200" preserveAspectRatio="xMidYMid meet"/>
+          <svg ref={graphElement2}/>
         </div>
 
         <div className="svg-parent is-gray">
@@ -468,7 +478,7 @@ function TimeSeries(props) {
               <h6>{timeseries.length>0 && index!==0 ? timeseries[index]['totaldeceased'] - timeseries[index-1]['totaldeceased']>=0 ? '+'+(timeseries[index]['totaldeceased'] - timeseries[index-1]['totaldeceased']) : (timeseries[index]['totaldeceased'] - timeseries[index-1]['totaldeceased']) : ''}</h6>
             </div>
           </div>
-          <svg ref={graphElement3} width="650" height="200" viewBox="0 0 650 200" preserveAspectRatio="xMidYMid meet"/>
+          <svg ref={graphElement3}/>
         </div>
 
       </div>
@@ -483,7 +493,7 @@ function TimeSeries(props) {
               <h6>{timeseries.length>0 && index!==0 ? timeseries[index]['dailyconfirmed'] - timeseries[index-1]['dailyconfirmed']>=0 ? '+'+(timeseries[index]['dailyconfirmed'] - timeseries[index-1]['dailyconfirmed']) : (timeseries[index]['dailyconfirmed'] - timeseries[index-1]['dailyconfirmed']) : ''}</h6>
             </div>
           </div>
-          <svg ref={graphElement4} width="650" height="200" viewBox="0 0 650 200" preserveAspectRatio="xMidYMid meet"/>
+          <svg ref={graphElement4}/>
         </div>
 
         <div className="svg-parent is-green">
@@ -494,7 +504,7 @@ function TimeSeries(props) {
               <h6>{timeseries.length>0 && index!==0 ? timeseries[index]['dailyrecovered'] - timeseries[index-1]['dailyrecovered']>=0 ? '+'+(timeseries[index]['dailyrecovered'] - timeseries[index-1]['dailyrecovered']) : (timeseries[index]['dailyrecovered'] - timeseries[index-1]['dailyrecovered']) : ''}</h6>
             </div>
           </div>
-          <svg ref={graphElement5} width="650" height="200" viewBox="0 0 650 200" preserveAspectRatio="xMidYMid meet"/>
+          <svg ref={graphElement5}/>
         </div>
 
         <div className="svg-parent is-gray">
@@ -505,7 +515,7 @@ function TimeSeries(props) {
               <h6>{timeseries.length>0 && index!==0 ? timeseries[index]['dailydeceased'] - timeseries[index-1]['dailydeceased']>=0 ? '+'+(timeseries[index]['dailydeceased'] - timeseries[index-1]['dailydeceased']) : (timeseries[index]['dailydeceased'] - timeseries[index-1]['dailydeceased']) : ''}</h6>
             </div>
           </div>
-          <svg ref={graphElement6} width="650" height="200" viewBox="0 0 650 200" preserveAspectRatio="xMidYMid meet"/>
+          <svg ref={graphElement6}/>
         </div>
 
       </div>

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -104,7 +104,7 @@ function TimeSeries(props) {
         .append('circle')
         .attr('fill', colors[i])
         .attr('stroke', colors[i])
-        .attr('r', 4)
+        .attr('r', 3)
         .attr('cx', x(new Date(data[timeseries.length-1]['date'] + '2020')))
         .attr('cy', y(data[timeseries.length-1][dataTypes[i]]));
     });
@@ -183,7 +183,7 @@ function TimeSeries(props) {
         .append('circle')
         .attr('fill', colors[i])
         .attr('stroke', colors[i])
-        .attr('r', 2)
+        .attr('r', 1)
         .attr('cursor', 'pointer')
         .attr('cx', function(d) {
           return x(new Date(d['date']+'2020'));

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -76,7 +76,8 @@ function TimeSeries(props) {
     const svg5 = d3.select(graphElement5.current);
     const svg6 = d3.select(graphElement6.current);
 
-    const dateMin = new Date(data[0]['date'] + '2020');
+    var dateMin = new Date(data[0]['date'] + '2020');
+    dateMin.setDate(dateMin.getDate() - 1);
     var dateMax = new Date(data[timeseries.length-1]['date'] + '2020');
     dateMax.setDate(dateMax.getDate() + 1);
 
@@ -95,7 +96,8 @@ function TimeSeries(props) {
       s.append('g')
         .attr('transform', 'translate(0,' + height + ')')
         .attr('class', 'axis')
-        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
+        .call(d3.axisBottom(x)
+          .ticks(width < 500 ? 3 : 5));
     });
 
     const dataTypes = ['totalconfirmed', 'totalrecovered', 'totaldeceased',
@@ -105,10 +107,9 @@ function TimeSeries(props) {
       return d3.max(data, (d) => { return +d[dataTypes[i]]; })
     })
 
-    console.log(maxDataTypes);
     const yScales = maxDataTypes.map((d) => {
       return d3.scaleLinear()
-              .domain([-d/10, d])
+              .domain([0, d])
               .range([height, margin.top]);
     });
 
@@ -173,22 +174,18 @@ function TimeSeries(props) {
 
     /* Paths */
     svgArray.forEach((s, i) => {
-      s.append('path')
-        .datum(data)
+      s.selectAll('stem-line')
+        .data(data)
+        .enter()
+        .append('line')
         .attr('fill', 'none')
         .attr('stroke', colors[i] + '99')
         .attr('stroke-width', 3)
         .attr('cursor', 'pointer')
-        .attr('d', d3.line()
-            .x(function(d) {
-              return x(new Date(d['date']+'2020'));
-            })
-            .y(function(d) {
-              if (mode) return yScales[0](d[dataTypes[i]]);
-              else return yScales[i](d[dataTypes[i]]);
-            })
-            .curve(d3.curveCardinal),
-        );
+        .attr('x1', (d) => { return x(new Date(d['date']+'2020'));})
+        .attr('y1', height)
+        .attr('x2', (d) => { return x(new Date(d['date']+'2020'));})
+        .attr('y2', (d) => { return mode ? yScales[0](d[dataTypes[i]]) : yScales[i](d[dataTypes[i]]);});
     });
 
     /* Path Dots */

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -83,50 +83,21 @@ function TimeSeries(props) {
         .domain([0, timeseries.length])
         .range([margin.left, width]);
 
+    // Arrays of objects
     const svgArray = [svg1, svg2, svg3, svg4, svg5, svg6];
-
     const dataTypes = ['totalconfirmed', 'totalrecovered', 'totaldeceased',
                        'dailyconfirmed', 'dailyrecovered', 'dailydeceased'];
-
+    const colors = ['#ff073a', '#28a745', '#6c757d', '#ff073a', '#28a745', '#6c757d'];
     const maxDataTypes = Array.from({ length: svgArray.length }, (_, i) => {
       return d3.max(data, (d) => { return +d[dataTypes[i]]; })
     })
-
     const yScales = maxDataTypes.map((d) => {
       return d3.scaleLinear()
               .domain([0, d])
               .range([height, margin.top]);
     });
 
-    /* X axis */
-    svgArray.forEach((s) => {
-      s.append('g')
-        .attr('transform', 'translate(0,' + height + ')')
-        .attr('class', 'axis')
-        .call(d3.axisBottom(x)
-          .ticks(width < 400 ? 3 : 5))
-        .call(g => g.selectAll(".tick text")
-          .style("font-size", '10px'));
-    });
-
-    /* Y axis */
-    svgArray.forEach((s, i) => {
-      s.append('g')
-        .attr('transform', `translate(${width}, ${0})`)
-        .attr('class', 'axis')
-        .call(d3.axisRight(mode ? yScales[0] : yScales[i])
-          .ticks(4)
-          .tickPadding(5)
-          .tickFormat((tick) => {
-            if (Math.floor(tick) === tick) { return tick; }
-          }))
-        .call(g => g.selectAll(".tick text")
-          .style("font-size", '10px'));
-      });
-
     /* Focus dots */
-    const colors = ['#ff073a', '#28a745', '#6c757d', '#ff073a', '#28a745', '#6c757d'];
-
     var focus = svgArray.map((d, i) => {
       const y = mode ? yScales[0] : yScales[i];
       return d.append('g')
@@ -163,14 +134,35 @@ function TimeSeries(props) {
       }
     };
 
-    svgArray.forEach(function (s) {
-        s.on("mousemove", mousemove).on("touchmove", mousemove)
-         .on("mouseout", mouseout).on("touchend", mouseout);
-    });
-
-
-    /* Paths */
+    /* Begin drawing chart */
     svgArray.forEach((s, i) => {
+      /* X axis */
+      s.append('g')
+        .attr('transform', 'translate(0,' + height + ')')
+        .attr('class', 'axis')
+        .call(d3.axisBottom(x)
+          .ticks(width < 400 ? 3 : 5))
+        .call(g => g.selectAll(".tick text")
+          .style("font-size", '10px'));
+
+      /* Y axis */
+      s.append('g')
+        .attr('transform', `translate(${width}, ${0})`)
+        .attr('class', 'axis')
+        .call(d3.axisRight(mode ? yScales[0] : yScales[i])
+          .ticks(4)
+          .tickPadding(5)
+          .tickFormat((tick) => {
+            if (Math.floor(tick) === tick) { return tick; }
+          }))
+        .call(g => g.selectAll(".tick text")
+          .style("font-size", '10px'));
+
+      /* Focus dots */
+      s.on("mousemove", mousemove).on("touchmove", mousemove)
+        .on("mouseout", mouseout).on("touchend", mouseout);
+
+      /* Paths */
       s.selectAll('stem-line')
         .data(data)
         .enter()
@@ -183,10 +175,8 @@ function TimeSeries(props) {
         .attr('y1', height)
         .attr('x2', (d) => { return x(new Date(d['date']+'2020'));})
         .attr('y2', (d) => { return mode ? yScales[0](d[dataTypes[i]]) : yScales[i](d[dataTypes[i]]);});
-    });
 
-    /* Path Dots */
-    svgArray.forEach((s, i) => {
+      /* Path Dots */
       s.selectAll('.dot')
         .data(data)
         .enter()

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -39,9 +39,9 @@ function TimeSeries(props) {
     }
   }, [update]);
 
-  let resizeObserver = new ResizeObserver(() => {
+  window.addEventListener('resize', () => {
     if (timeseries.length>1) {
-      refreshGraphs(graphData);
+      refreshGraphs();
     }
   });
 
@@ -59,9 +59,6 @@ function TimeSeries(props) {
     const data = timeseries;
     setDatapoint(timeseries[timeseries.length-1]);
     setIndex(timeseries.length-1);
-
-    var el = document.getElementById("svg1");
-    resizeObserver.observe(el);
 
     const svg1 = d3.select(graphElement1.current);
     const margin = {top: 20, right: 40, bottom: 25, left: 15};

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -60,10 +60,11 @@ function TimeSeries(props) {
     setDatapoint(timeseries[timeseries.length-1]);
     setIndex(timeseries.length-1);
 
-    var el = document.getElementById("123");
+    var el = document.getElementById("svg1");
     resizeObserver.observe(el);
+
     const svg1 = d3.select(graphElement1.current);
-    const margin = {top: 20, right: 20, bottom: 10, left: 20};
+    const margin = {top: 20, right: 20, bottom: 10, left: 30};
     const pwidth = svg1.node().getBoundingClientRect().width;
     const pheight = svg1.node().getBoundingClientRect().height;
     const width = pwidth - margin.left - margin.right;
@@ -86,27 +87,27 @@ function TimeSeries(props) {
     svg1.append('g')
         .attr('transform', 'translate(0,' + height + ')')
         .attr('class', 'axis')
-        .call(d3.axisBottom(x));
+        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
 
     svg2.append('g')
         .attr('transform', 'translate(0,' + height + ')')
         .attr('class', 'axis')
-        .call(d3.axisBottom(x));
+        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
 
     svg3.append('g')
         .attr('transform', 'translate(0,' + height + ')')
         .attr('class', 'axis')
-        .call(d3.axisBottom(x));
+        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
 
     svg4.append('g')
         .attr('transform', 'translate(0,' + height + ')')
         .attr('class', 'axis')
-        .call(d3.axisBottom(x));
+        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
 
     svg5.append('g')
         .attr('transform', 'translate(0,' + height + ')')
         .attr('class', 'axis')
-        .call(d3.axisBottom(x));
+        .call(d3.axisBottom(x).ticks(width < 500 ? 3 : 5));
 
     svg6.append('g')
         .attr('transform', 'translate(0,' + height + ')')
@@ -448,7 +449,7 @@ function TimeSeries(props) {
     <div className="TimeSeries-Parent fadeInUp" style={{animationDelay: '1.7s'}}>
       <div className="timeseries" style={{display: props.type===1 ? 'flex' : 'none'}}>
 
-        <div className="svg-parent" id="123">
+        <div className="svg-parent" id="svg1">
           <div className="stats">
             <h5>Confirmed {datapoint['date']}</h5>
             <div className="stats-bottom">

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -39,12 +39,6 @@ function TimeSeries(props) {
     }
   }, [update]);
 
-  window.addEventListener('resize', () => {
-    if (timeseries.length>1) {
-      refreshGraphs();
-    }
-  });
-
   const refreshGraphs = () => {
     const graphs = [graphElement1, graphElement2, graphElement3, graphElement4, graphElement5, graphElement6];
     for (let i=0; i<=graphs.length; i++) {

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -64,11 +64,11 @@ function TimeSeries(props) {
     resizeObserver.observe(el);
 
     const svg1 = d3.select(graphElement1.current);
-    const margin = {top: 20, right: 15, bottom: 10, left: 25};
+    const margin = {top: 20, right: 40, bottom: 25, left: 15};
     const pwidth = svg1.node().getBoundingClientRect().width;
     const pheight = svg1.node().getBoundingClientRect().height;
-    const width = pwidth - margin.left - margin.right;
-    const height = pheight - margin.top - margin.bottom;
+    const width = pwidth - margin.right;
+    const height = pheight - margin.bottom;
 
     const svg2 = d3.select(graphElement2.current);
     const svg3 = d3.select(graphElement3.current);
@@ -87,18 +87,9 @@ function TimeSeries(props) {
 
     const indexScale = d3.scaleLinear()
         .domain([0, timeseries.length])
-        .range([margin.left,width]);
+        .range([margin.left, width]);
 
     const svgArray = [svg1, svg2, svg3, svg4, svg5, svg6];
-
-    /* X axis */
-    svgArray.forEach((s) => {
-      s.append('g')
-        .attr('transform', 'translate(0,' + height + ')')
-        .attr('class', 'axis')
-        .call(d3.axisBottom(x)
-          .ticks(width < 500 ? 3 : 5));
-    });
 
     const dataTypes = ['totalconfirmed', 'totalrecovered', 'totaldeceased',
                        'dailyconfirmed', 'dailyrecovered', 'dailydeceased'];
@@ -113,19 +104,31 @@ function TimeSeries(props) {
               .range([height, margin.top]);
     });
 
+    /* X axis */
+    svgArray.forEach((s) => {
+      s.append('g')
+        .attr('transform', 'translate(0,' + height + ')')
+        .attr('class', 'axis')
+        .call(d3.axisBottom(x)
+          .ticks(width < 400 ? 3 : 5))
+        .call(g => g.selectAll(".tick text")
+          .style("font-size", '10px'));
+    });
+
     /* Y axis */
     svgArray.forEach((s, i) => {
       s.append('g')
         .attr('transform', `translate(${width}, ${0})`)
         .attr('class', 'axis')
         .call(d3.axisRight(mode ? yScales[0] : yScales[i])
-          .ticks(5)
+          .ticks(4)
           .tickPadding(5)
           .tickFormat((tick) => {
             if (Math.floor(tick) === tick) { return tick; }
-          })
-        );
-    });
+          }))
+        .call(g => g.selectAll(".tick text")
+          .style("font-size", '10px'));
+      });
 
     /* Focus dots */
     const colors = ['#ff073a', '#28a745', '#6c757d', '#ff073a', '#28a745', '#6c757d'];

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -55,17 +55,20 @@ function TimeSeries(props) {
     setIndex(timeseries.length-1);
 
     const svg1 = d3.select(graphElement1.current);
-    const margin = {top: 20, right: 40, bottom: 25, left: 15};
-    const pwidth = svg1.node().getBoundingClientRect().width;
-    const pheight = svg1.node().getBoundingClientRect().height;
-    const width = pwidth - margin.right;
-    const height = pheight - margin.bottom;
-
     const svg2 = d3.select(graphElement2.current);
     const svg3 = d3.select(graphElement3.current);
     const svg4 = d3.select(graphElement4.current);
     const svg5 = d3.select(graphElement5.current);
     const svg6 = d3.select(graphElement6.current);
+
+    // Margins
+    const margin = {top: 20, right: 40, bottom: 25, left: 15};
+    // Required width
+    let referenceSvg = (props.type === 1) ? svg1 : svg4;
+    const pwidth = referenceSvg.node().getBoundingClientRect().width;
+    const pheight = referenceSvg.node().getBoundingClientRect().height;
+    const width = pwidth - margin.right;
+    const height = pheight - margin.bottom;
 
     var dateMin = new Date(data[0]['date'] + '2020');
     dateMin.setDate(dateMin.getDate() - 1);


### PR DESCRIPTION
Contains a lot of changes at once. Feel free to cherry-pick.  
- ~~Added a handler which re-renders charts on change in window resize. Trend charts have a fixed aspect ratio which restricts them from scaling properly on different devices when the window size is changed.~~*
- Delete a lot of duplicate code by vectorizing all charting functions
- Also switched to stem plots which serve a somewhat similar purpose as bar graph (#189). 
Fixes #200.

*Note: Ideally, the re-render should be triggered only when the specified chart area changes and not the whole window. This can be done using something like resizeObserver, but this API is not supported on all browsers. **Reverted since it's causing performance issues. Manual page refresh required now.**
