### PR TITLE
Remove default uniform scaling

### DIFF
--- a/src/components/home.js
+++ b/src/components/home.js
@@ -18,7 +18,7 @@ function Home(props) {
   const [lastUpdated, setLastUpdated] = useState('');
   const [timeseries, setTimeseries] = useState([]);
   const [deltas, setDeltas] = useState([]);
-  const [timeseriesMode, setTimeseriesMode] = useState(true);
+  const [timeseriesMode, setTimeseriesMode] = useState(false);
   const [stateHighlighted, setStateHighlighted] = useState(undefined);
 
   useEffect(()=> {


### PR DESCRIPTION
The graphs are getting obscure because of wrong scale. Please let's not scale uniformly. This is much better picture for death and recoveries:

![image](https://user-images.githubusercontent.com/5961873/77817052-f351b600-70ed-11ea-9284-e4f4d3638e39.png)

Same for **Daily**. At first look, it seems like nothing is changing much but in real the spikes are huge (check last screenshot below):

![image](https://user-images.githubusercontent.com/5961873/77817087-285e0880-70ee-11ea-9c92-4139ca5c962c.png)

![image](https://user-images.githubusercontent.com/5961873/77817093-2eec8000-70ee-11ea-9bd7-070af95ab509.png)
