### PR TITLE
fix: a11y & sticky table header hover opacity

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -442,6 +442,12 @@ abbr {
   }
 }
 
+.affected-count {
+  text-align: right;
+  margin: 1rem 0 0 0;
+  color: $gray-mid;
+}
+
 table {
   position: relative;
   width: 30rem;
@@ -449,7 +455,6 @@ table {
   font-family: 'archia';
   text-transform: uppercase;
   margin-bottom: 1rem;
-  margin-top: 2rem;
   thead {
     background: $gray-light;
     color: $gray-dark;
@@ -465,7 +470,7 @@ table {
 		background: rgb(241, 241, 241);
 	  }
       &:hover {
-        background: $gray-hover;
+        background: #ECEDEE;
       }
       .heading-content {
         display: flex;
@@ -489,7 +494,7 @@ table {
     }
   }
   &:nth-child(odd){
-    background-color: $light;
+    background-color: $white;
   }
   tbody {
     color: $gray;
@@ -518,7 +523,7 @@ table {
       }
     }
 
-    &:nth-child(odd){
+    &:nth-child(even){
       background-color: $light;
       &.spacer {
         background: transparent !important;

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -115,6 +115,7 @@ function Home(props) {
                 <label htmlFor="timeseries-mode">Scale Uniformly</label>
                 <input
                   type="checkbox"
+                  aria-label="Checked by default to scale uniformly."
                   checked={timeseriesMode}
                   onChange={(event) => {
                     setTimeseriesMode(!timeseriesMode);

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -16,6 +16,7 @@ function Navbar(props) {
       >
         <img
           className="fadeInUp"
+          alt="India COVID-19 Tracker"
           src="/icon.png"
           style={{
             animationDelay: "0.0s",

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -99,73 +99,75 @@ function Table(props) {
   doSort();
 
   return (
-    <table className="table fadeInUp" style={{animationDelay: '1s'}}>
-      <h5 className="affected-count">{count} States/UTS Affected</h5>
-      <thead>
-        <tr>
-          <th className="sticky state-heading" onClick={(e) => handleSort(e, props)} >
-            <div className='heading-content'>
-              <abbr title="State">
-                  State/UT
-              </abbr>
-              <div style={{display: sortData.sortColumn === 'state' ? 'initial': 'none'}}>
-                {sortData.isAscending ? <Icon.ArrowDown/> : <Icon.ArrowUp/>}
+    <>
+      <h5 className="affected-count fadeInUp" style={{animationDelay: '1s'}}>{count} States/UTS Affected</h5>
+      <table className="table fadeInUp" style={{animationDelay: '1s'}}>
+        <thead>
+          <tr>
+            <th className="sticky state-heading" onClick={(e) => handleSort(e, props)} >
+              <div className='heading-content'>
+                <abbr title="State">
+                    State/UT
+                </abbr>
+                <div style={{display: sortData.sortColumn === 'state' ? 'initial': 'none'}}>
+                  {sortData.isAscending ? <Icon.ArrowDown/> : <Icon.ArrowUp/>}
+                </div>
               </div>
-            </div>
-          </th>
-          <th className="sticky" onClick={(e) => handleSort(e, props)}>
-            <div className='heading-content'>
-              <abbr className={`${window.innerWidth <=769 ? 'is-cherry' : ''}`} title="Confirmed">{window.innerWidth <=769 ? window.innerWidth <=375 ? 'C' : 'Cnfmd' : 'Confirmed'}</abbr>
-              <div style={{display: sortData.sortColumn === 'confirmed' ? 'initial': 'none'}}>
-                {sortData.isAscending ? <Icon.ArrowDown/> : <Icon.ArrowUp/>}
+            </th>
+            <th className="sticky" onClick={(e) => handleSort(e, props)}>
+              <div className='heading-content'>
+                <abbr className={`${window.innerWidth <=769 ? 'is-cherry' : ''}`} title="Confirmed">{window.innerWidth <=769 ? window.innerWidth <=375 ? 'C' : 'Cnfmd' : 'Confirmed'}</abbr>
+                <div style={{display: sortData.sortColumn === 'confirmed' ? 'initial': 'none'}}>
+                  {sortData.isAscending ? <Icon.ArrowDown/> : <Icon.ArrowUp/>}
+                </div>
               </div>
-            </div>
-          </th>
-          <th className="sticky" onClick={(e) => handleSort(e, props)}>
-            <div className='heading-content'>
-              <abbr className={`${window.innerWidth <=769 ? 'is-blue' : ''}`} title="Active">{window.innerWidth <=769 ? window.innerWidth <=375 ? 'A' : 'Actv' : 'Active'}</abbr>
-              <div style={{display: sortData.sortColumn === 'active' ? 'initial': 'none'}}>
-                {sortData.isAscending ? <Icon.ArrowDown/> : <Icon.ArrowUp/>}
+            </th>
+            <th className="sticky" onClick={(e) => handleSort(e, props)}>
+              <div className='heading-content'>
+                <abbr className={`${window.innerWidth <=769 ? 'is-blue' : ''}`} title="Active">{window.innerWidth <=769 ? window.innerWidth <=375 ? 'A' : 'Actv' : 'Active'}</abbr>
+                <div style={{display: sortData.sortColumn === 'active' ? 'initial': 'none'}}>
+                  {sortData.isAscending ? <Icon.ArrowDown/> : <Icon.ArrowUp/>}
+                </div>
               </div>
-            </div>
-          </th>
-          <th  className="sticky" onClick={(e) => handleSort(e, props)}>
-            <div className='heading-content'>
-              <abbr className={`${window.innerWidth <=769 ? 'is-green' : ''}`} title="Recovered">{window.innerWidth <=769 ? window.innerWidth <=375 ? 'R' : 'Rcvrd' : 'Recovered'}</abbr>
-              <div className={ sortData.sortColumn === 'recovered'? 'sort-black' : ''}></div>
-              <div style={{display: sortData.sortColumn === 'recovered' ? 'initial': 'none'}}>
-                {sortData.isAscending ? <Icon.ArrowDown/> : <Icon.ArrowUp/>}
+            </th>
+            <th  className="sticky" onClick={(e) => handleSort(e, props)}>
+              <div className='heading-content'>
+                <abbr className={`${window.innerWidth <=769 ? 'is-green' : ''}`} title="Recovered">{window.innerWidth <=769 ? window.innerWidth <=375 ? 'R' : 'Rcvrd' : 'Recovered'}</abbr>
+                <div className={ sortData.sortColumn === 'recovered'? 'sort-black' : ''}></div>
+                <div style={{display: sortData.sortColumn === 'recovered' ? 'initial': 'none'}}>
+                  {sortData.isAscending ? <Icon.ArrowDown/> : <Icon.ArrowUp/>}
+                </div>
               </div>
-            </div>
-          </th>
-          <th className="sticky" onClick={(e) => handleSort(e, props)}>
-            <div className='heading-content'>
-              <abbr className={`${window.innerWidth <=769 ? 'is-gray' : ''}`} title="Deaths">{window.innerWidth <=769 ? window.innerWidth <=375 ? 'D' : 'Dcsd' : 'Deceased'}</abbr>
-              <div style={{display: sortData.sortColumn === 'deaths' ? 'initial': 'none'}}>
-                {sortData.isAscending ? <Icon.ArrowDown/> : <Icon.ArrowUp/>}
+            </th>
+            <th className="sticky" onClick={(e) => handleSort(e, props)}>
+              <div className='heading-content'>
+                <abbr className={`${window.innerWidth <=769 ? 'is-gray' : ''}`} title="Deaths">{window.innerWidth <=769 ? window.innerWidth <=375 ? 'D' : 'Dcsd' : 'Deceased'}</abbr>
+                <div style={{display: sortData.sortColumn === 'deaths' ? 'initial': 'none'}}>
+                  {sortData.isAscending ? <Icon.ArrowDown/> : <Icon.ArrowUp/>}
+                </div>
               </div>
-            </div>
-          </th>
-        </tr>
-      </thead>
+            </th>
+          </tr>
+        </thead>
 
-      {
-        states.map((state, index) => {
-          if (index!==0 && state.confirmed>0) {
-            return (
-              <tbody>
-                <Row key={index} index={index} state={state} total={false} reveal={revealedStates[state.state]} districts={Object.keys(districts).length-1 > 0 ? districts[state.state].districtData : []} onHighlightState={props.onHighlightState} handleReveal={handleReveal} />
-              </tbody>
-            );
-          }
-        })
-      }
+        {
+          states.map((state, index) => {
+            if (index!==0 && state.confirmed>0) {
+              return (
+                <tbody>
+                  <Row key={index} index={index} state={state} total={false} reveal={revealedStates[state.state]} districts={Object.keys(districts).length-1 > 0 ? districts[state.state].districtData : []} onHighlightState={props.onHighlightState} handleReveal={handleReveal} />
+                </tbody>
+              );
+            }
+          })
+        }
 
-      <tbody>
-        {states.length > 1 && props.summary===false && <Row key={0} state={states[0]} total={true}/>}
-      </tbody>
+        <tbody>
+          {states.length > 1 && props.summary===false && <Row key={0} state={states[0]} total={true}/>}
+        </tbody>
 
-    </table>
+      </table>
+    </>
   );
 }
 


### PR DESCRIPTION
- Placed h5.affected-count outside table as it is not a table element. Changed its styles in App.scss as needed.
- Added aria-label and alt on checkbox and icon.
- Changed sticky table header's background-color from transparent to opaque so the state names aren't visible in the background on hover.

Closes #287 