### PR TITLE
Fix: Table backgrounds

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -572,10 +572,11 @@ table {
 
   tbody {
     color: $gray;
-
+    
     tr {
       transition: background 0.1s ease-in-out;
       cursor: pointer;
+      background: $light;
 
       &:hover {
         background: $gray-hover;
@@ -593,23 +594,27 @@ table {
     }
 
     & > tr:nth-child(odd) {
-      background: $light;
-
       &:hover {
         background: $gray-hover;
       }
+      // &:nth-child(odd) {
+      //   background: $white ;
+      // }
+    }
 
-      &:nth-child(odd) {
-        background: $white !important;
+    & > tr:nth-child() {
+      &:hover{
+        background: $gray-hover ;
       }
     }
 
-    &:nth-child(even) {
-      background-color: $light;
+    
 
+    &:nth-child(odd){
       &.spacer {
         background: transparent !important;
       }
+      
     }
 
     td {
@@ -617,7 +622,6 @@ table {
       font-size: 0.9rem;
       border-radius: 5px;
       text-align: right;
-
       .deltas {
         margin-right: 0.25rem;
         font-size: 11px !important;
@@ -630,6 +634,7 @@ table {
         }
       }
     }
+
 
     td:first-child {
       text-align: left;


### PR DESCRIPTION
There is a lack of feedback within the districts table for odd indexed districts. 
There is a lack of consistency within the districts table for multiple states as shown in image 

Changes have been made to the css file.


Attached images 

Bug : 
![bugRandomBackground](https://user-images.githubusercontent.com/19794190/77844709-6595c980-71c6-11ea-8892-1d2d637eda22.png)
 
Fix : 
![fixed](https://user-images.githubusercontent.com/19794190/77844703-60387f00-71c6-11ea-88fa-c4f3ce5fba14.png)







