### PR TITLE
Feature #317 : Rate of New Cases

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -459,6 +459,7 @@ h6 {
   .is-cherry {
     h1 { color: $cherry; }
 
+    h2,
     h4,
     h5 { color: $cherry-mid; }
   }
@@ -466,6 +467,7 @@ h6 {
   .is-blue {
     h1 { color: $blue; }
 
+    h2,
     h4,
     h5 { color: $blue-mid; }
   }
@@ -473,6 +475,7 @@ h6 {
   .is-green {
     h1 { color: $green; }
 
+    h2,
     h4,
     h5 { color: $green-mid; }
   }

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -4,6 +4,7 @@ import {formatDistance} from 'date-fns';
 
 import Table from './table';
 import Level from './level';
+import RateOfNewCases from './newcases';
 import MapExplorer from './mapexplorer';
 import TimeSeries from './timeseries';
 import Minigraph from './minigraph';
@@ -80,6 +81,7 @@ function Home(props) {
 
         <Level data={states} deltas={deltas} />
         <Minigraph timeseries={timeseries} animate={true} />
+        <RateOfNewCases data={states} deltas={deltas} timeseries={timeseries} />
 
         <Table
           states={states}

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -41,42 +41,34 @@ function RateOfNewCases(props) {
   function displayRateOfNewCases() {
     const rows = [];
     for (let index = casesMap.length - 1; index > 0; index--) {
+      const casesDiff = casesMap[index - 1].cases - casesMap[index].cases;
+      const isToday = casesMap[index - 1].date === 'Today';
       rows.push(
-        <React.Fragment>
+        <React.Fragment key={index}>
           {index < casesMap.length - 1 && (
             <div
               className={`level-item ${
-                casesMap[index - 1].cases - casesMap[index].cases < 0
-                  ? casesMap[index - 1].date == 'Today'
-                    ? 'is-blue'
-                    : 'is-green'
-                  : 'is-cherry'
+                casesDiff < 0 ? (isToday ? 'is-blue' : 'is-green') : 'is-cherry'
               }`}
             >
               <h5 className="heading"> </h5>
               <h1>
-                {casesMap[index - 1].cases - casesMap[index].cases > 0
-                  ? upArrow
-                  : downArrow}
-                {Math.abs(casesMap[index - 1].cases - casesMap[index].cases)}
-                {casesMap[index - 1].date == 'Today' ? '*' : ''}
+                {casesDiff > 0 ? upArrow : downArrow}
+                {Math.abs(casesDiff)}
+                {isToday ? '*' : ''}
               </h1>
-              <h1 className="title has-text-grey">{}</h1>
+              <h1 className="title has-text-grey"></h1>
             </div>
           )}
           <div
             className={`level-item ${
-              casesMap[index - 1].cases - casesMap[index].cases < 0
-                ? casesMap[index - 1].date == 'Today'
-                  ? 'is-blue'
-                  : 'is-green'
-                : 'is-cherry'
+              casesDiff < 0 ? (isToday ? 'is-blue' : 'is-green') : 'is-cherry'
             }`}
           >
             <h5 className="heading">{casesMap[index - 1].date}</h5>
             <h2 className="title has-text-grey">
               {casesMap[index - 1].cases}
-              {casesMap[index - 1].date == 'Today' ? '*' : ''}
+              {isToday ? '*' : ''}
             </h2>
           </div>
         </React.Fragment>

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -1,28 +1,36 @@
 import React, {useState, useEffect} from 'react';
 
 function RateOfNewCases(props) {
-  const [yesterdayCases, setYesterdayCases] = useState(0);
-  const [todayCases, setTodayCases] = useState(0);
-  const [secondLastDayCases, setSecondLastDayCases] = useState(0);
-  const [secondLastDayDate, setSecondLastDayDate] = useState(0);
-  const [thirdLastDayCases, setThirdLastDayCases] = useState(0);
-  const [fourthLastDayCases, setFourthLastDayCases] = useState(0);
-  const [thirdLastDayDate, setThirdLastDayDate] = useState(0);
+  const [firstDayCases, setFirstDayCases] = useState(0);
+  const [firstDayDate, setFirstDayDate] = useState(0);
+  const [secondDayCases, setSecondDayCases] = useState(0);
+  const [secondDayDate, setSecondDayDate] = useState(0);
+  const [thirdDayCases, setThirdDayCases] = useState(0);
+  const [thirdDayDate, setThirdDayDate] = useState(0);
+  const [fourthDayCases, setFourthDayCases] = useState(0);
+  const [fourthDayDate, setFourthDayDate] = useState(0);
+  const [fifthDayCases, setFifthDayCases] = useState(0);
+  const [upArrow, setUpArrow] = useState(0);
+  const [downArrow, setDownArrow] = useState(0);
 
   useEffect(() => {
     parseData();
+    setUpArrow(String.fromCharCode(8593));
+    setDownArrow(String.fromCharCode(8595));
   });
 
   const parseData = () => {
     const length = props.timeseries.length;
     if (length > 0) {
-      setYesterdayCases(props.timeseries[length - 1]['dailyconfirmed']);
-      setSecondLastDayCases(props.timeseries[length - 2]['dailyconfirmed']);
-      setSecondLastDayDate(props.timeseries[length - 2]['date']);
-      setThirdLastDayCases(props.timeseries[length - 3]['dailyconfirmed']);
-      setThirdLastDayDate(props.timeseries[length - 3]['date']);
-      setFourthLastDayCases(props.timeseries[length - 4]['dailyconfirmed']);
-      setTodayCases(props.deltas.confirmeddelta);
+      setFirstDayCases(props.deltas.confirmeddelta);
+      setFirstDayDate('Today');
+      setSecondDayCases(props.timeseries[length - 1]['dailyconfirmed']);
+      setSecondDayDate('Yesterday');
+      setThirdDayCases(props.timeseries[length - 2]['dailyconfirmed']);
+      setThirdDayDate(props.timeseries[length - 2]['date']);
+      setFourthDayCases(props.timeseries[length - 3]['dailyconfirmed']);
+      setFourthDayDate(props.timeseries[length - 3]['date']);
+      setFifthDayCases(props.timeseries[length - 4]['dailyconfirmed']);
     }
   };
 
@@ -34,81 +42,69 @@ function RateOfNewCases(props) {
       <div className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
         <div
           className={`level-item ${
-            thirdLastDayCases - fourthLastDayCases < 0
-              ? 'is-green'
-              : 'is-cherry'
+            fourthDayCases - fifthDayCases < 0 ? 'is-green' : 'is-cherry'
           }`}
         >
-          <h5 className="heading">{thirdLastDayDate}</h5>
-          <h2 className="title has-text-grey">{thirdLastDayCases}</h2>
+          <h5 className="heading">{fourthDayDate}</h5>
+          <h2 className="title has-text-grey">{fourthDayCases}</h2>
         </div>
 
         <div
           className={`level-item ${
-            secondLastDayCases - thirdLastDayCases < 0
-              ? 'is-green'
-              : 'is-cherry'
+            thirdDayCases - fourthDayCases < 0 ? 'is-green' : 'is-cherry'
           }`}
         >
           <h5 className="heading"> </h5>
           <h1>
-            {secondLastDayCases - thirdLastDayCases > 0
-              ? String.fromCharCode(8593)
-              : String.fromCharCode(8595)}
-            {Math.abs(secondLastDayCases - thirdLastDayCases)}
+            {thirdDayCases - fourthDayCases > 0 ? upArrow : downArrow}
+            {Math.abs(thirdDayCases - fourthDayCases)}
           </h1>
           <h1 className="title has-text-grey">{}</h1>
         </div>
 
         <div
           className={`level-item ${
-            secondLastDayCases - thirdLastDayCases < 0
-              ? 'is-green'
-              : 'is-cherry'
+            thirdDayCases - fourthDayCases < 0 ? 'is-green' : 'is-cherry'
           }`}
         >
-          <h5 className="heading">{secondLastDayDate}</h5>
-          <h2 className="title has-text-success">{secondLastDayCases} </h2>
+          <h5 className="heading">{thirdDayDate}</h5>
+          <h2 className="title has-text-success">{thirdDayCases} </h2>
         </div>
 
         <div
           className={`level-item ${
-            yesterdayCases - secondLastDayCases < 0 ? 'is-green' : 'is-cherry'
+            secondDayCases - thirdDayCases < 0 ? 'is-green' : 'is-cherry'
           }`}
         >
           <h5 className="heading has-text-info">{} </h5>
           <h1 className="has-text-info">
-            {yesterdayCases - secondLastDayCases > 0
-              ? String.fromCharCode(8593)
-              : String.fromCharCode(8595)}
-            {Math.abs(yesterdayCases - secondLastDayCases)}
+            {secondDayCases - thirdDayCases > 0 ? upArrow : downArrow}
+            {Math.abs(secondDayCases - thirdDayCases)}
           </h1>
           <h1 className="title has-text-grey">{}</h1>
         </div>
 
         <div
           className={`level-item ${
-            yesterdayCases - secondLastDayCases < 0 ? 'is-green' : 'is-cherry'
+            secondDayCases - thirdDayCases < 0 ? 'is-green' : 'is-cherry'
           }`}
         >
-          <h5 className="heading">Yesterday</h5>
-          <h2 className="title has-text-info">{yesterdayCases}</h2>
+          <h5 className="heading">{secondDayDate}</h5>
+          <h2 className="title has-text-info">{secondDayCases}</h2>
         </div>
 
         <div className="level-item is-blue">
           <h5 className="heading"> </h5>
           <h1>
-            {todayCases - yesterdayCases > 0
-              ? String.fromCharCode(8593)
-              : String.fromCharCode(8595)}
-            {Math.abs(todayCases - yesterdayCases)}*
+            {firstDayCases - secondDayCases > 0 ? upArrow : downArrow}
+            {Math.abs(firstDayCases - secondDayCases)}*
           </h1>
           <h1 className="title has-text-grey">{}</h1>
         </div>
 
         <div className="level-item is-blue">
-          <h5>Today</h5>
-          <h2> {todayCases}* </h2>
+          <h5>{firstDayDate}</h5>
+          <h2> {firstDayCases}* </h2>
         </div>
       </div>
     </div>

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -8,7 +8,7 @@ function RateOfNewCases(props) {
 
   useEffect(() => {
     parseData();
-  });
+  }, [props.timeseries, props.deltas]);
 
   const parseData = () => {
     const length = props.timeseries.length;
@@ -42,12 +42,12 @@ function RateOfNewCases(props) {
 
   return (
     <div className="home-left">
-      <h2 className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
-        Rate of New Cases
-      </h2>
-      <div className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
-        {length > 0 && (
-          <React.Fragment>
+      {length > 0 && (
+        <React.Fragment>
+          <h2 className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
+            Rate of New Cases
+          </h2>
+          <div className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
             <div
               className={`level-item ${
                 casesMap[3].cases - casesMap[4].cases < 0
@@ -130,9 +130,9 @@ function RateOfNewCases(props) {
               <h5>{casesMap[0].date}</h5>
               <h2> {casesMap[0].cases}* </h2>
             </div>
-          </React.Fragment>
-        )}
-      </div>
+          </div>
+        </React.Fragment>
+      )}
     </div>
   );
 }

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -2,7 +2,6 @@ import React, {useState, useEffect} from 'react';
 
 function RateOfNewCases(props) {
   const [casesMap, setCasesMap] = useState(0);
-  const [length, setLength] = useState(0);
   const upArrow = String.fromCharCode(8593);
   const downArrow = String.fromCharCode(8595);
 
@@ -36,69 +35,66 @@ function RateOfNewCases(props) {
         },
       ];
       setCasesMap(casesDetails);
-      setLength(length);
     }
   };
 
-  return (
-    <div className="home-left">
-      {length > 0 && (
+  function displayRateOfNewCases() {
+    const rows = [];
+    for (let index = casesMap.length - 1; index > 0; index--) {
+      rows.push(
         <React.Fragment>
-          <h2 className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
-            Rate of New Cases
-          </h2>
-          <div className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
-            {(function () {
-              const rows = [];
-              for (let index = casesMap.length - 1; index > 0; index--) {
-                rows.push(
-                  <React.Fragment>
-                    {index < casesMap.length - 1 && (
-                      <div
-                        className={`level-item ${
-                          casesMap[index - 1].cases - casesMap[index].cases < 0
-                            ? casesMap[index - 1].date == 'Today'
-                              ? 'is-blue'
-                              : 'is-green'
-                            : 'is-cherry'
-                        }`}
-                      >
-                        <h5 className="heading"> </h5>
-                        <h1>
-                          {casesMap[index - 1].cases - casesMap[index].cases > 0
-                            ? upArrow
-                            : downArrow}
-                          {Math.abs(
-                            casesMap[index - 1].cases - casesMap[index].cases
-                          )}
-                          {casesMap[index - 1].date == 'Today' ? '*' : ''}
-                        </h1>
-                        <h1 className="title has-text-grey">{}</h1>
-                      </div>
-                    )}
-                    <div
-                      className={`level-item ${
-                        casesMap[index - 1].cases - casesMap[index].cases < 0
-                          ? casesMap[index - 1].date == 'Today'
-                            ? 'is-blue'
-                            : 'is-green'
-                          : 'is-cherry'
-                      }`}
-                    >
-                      <h5 className="heading">{casesMap[index - 1].date}</h5>
-                      <h2 className="title has-text-grey">
-                        {casesMap[index - 1].cases}
-                        {casesMap[index - 1].date == 'Today' ? '*' : ''}
-                      </h2>
-                    </div>
-                  </React.Fragment>
-                );
-              }
-              return rows;
-            })()}
+          {index < casesMap.length - 1 && (
+            <div
+              className={`level-item ${
+                casesMap[index - 1].cases - casesMap[index].cases < 0
+                  ? casesMap[index - 1].date == 'Today'
+                    ? 'is-blue'
+                    : 'is-green'
+                  : 'is-cherry'
+              }`}
+            >
+              <h5 className="heading"> </h5>
+              <h1>
+                {casesMap[index - 1].cases - casesMap[index].cases > 0
+                  ? upArrow
+                  : downArrow}
+                {Math.abs(casesMap[index - 1].cases - casesMap[index].cases)}
+                {casesMap[index - 1].date == 'Today' ? '*' : ''}
+              </h1>
+              <h1 className="title has-text-grey">{}</h1>
+            </div>
+          )}
+          <div
+            className={`level-item ${
+              casesMap[index - 1].cases - casesMap[index].cases < 0
+                ? casesMap[index - 1].date == 'Today'
+                  ? 'is-blue'
+                  : 'is-green'
+                : 'is-cherry'
+            }`}
+          >
+            <h5 className="heading">{casesMap[index - 1].date}</h5>
+            <h2 className="title has-text-grey">
+              {casesMap[index - 1].cases}
+              {casesMap[index - 1].date == 'Today' ? '*' : ''}
+            </h2>
           </div>
         </React.Fragment>
-      )}
+      );
+    }
+    return rows;
+  }
+
+  return (
+    <div className="home-left">
+      <React.Fragment>
+        <h2 className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
+          Rate of New Cases
+        </h2>
+        <div className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
+          {displayRateOfNewCases()}
+        </div>
+      </React.Fragment>
     </div>
   );
 }

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -48,88 +48,52 @@ function RateOfNewCases(props) {
             Rate of New Cases
           </h2>
           <div className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
-            <div
-              className={`level-item ${
-                casesMap[3].cases - casesMap[4].cases < 0
-                  ? 'is-green'
-                  : 'is-cherry'
-              }`}
-            >
-              <h5 className="heading">{casesMap[3].date}</h5>
-              <h2 className="title has-text-grey">{casesMap[3].cases}</h2>
-            </div>
-
-            <div
-              className={`level-item ${
-                casesMap[2].cases - casesMap[3].cases < 0
-                  ? 'is-green'
-                  : 'is-cherry'
-              }`}
-            >
-              <h5 className="heading"> </h5>
-              <h1>
-                {casesMap[2].cases - casesMap[3].cases > 0
-                  ? upArrow
-                  : downArrow}
-                {Math.abs(casesMap[2].cases - casesMap[3].cases)}
-              </h1>
-              <h1 className="title has-text-grey">{}</h1>
-            </div>
-
-            <div
-              className={`level-item ${
-                casesMap[2].cases - casesMap[3].cases < 0
-                  ? 'is-green'
-                  : 'is-cherry'
-              }`}
-            >
-              <h5 className="heading">{casesMap[2].date}</h5>
-              <h2 className="title has-text-success">{casesMap[2].cases} </h2>
-            </div>
-
-            <div
-              className={`level-item ${
-                casesMap[1].cases - casesMap[2].cases < 0
-                  ? 'is-green'
-                  : 'is-cherry'
-              }`}
-            >
-              <h5 className="heading has-text-info">{} </h5>
-              <h1 className="has-text-info">
-                {casesMap[1].cases - casesMap[2].cases > 0
-                  ? upArrow
-                  : downArrow}
-                {Math.abs(casesMap[1].cases - casesMap[2].cases)}
-              </h1>
-              <h1 className="title has-text-grey">{}</h1>
-            </div>
-
-            <div
-              className={`level-item ${
-                casesMap[1].cases - casesMap[2].cases < 0
-                  ? 'is-green'
-                  : 'is-cherry'
-              }`}
-            >
-              <h5 className="heading">{casesMap[1].date}</h5>
-              <h2 className="title has-text-info">{casesMap[1].cases}</h2>
-            </div>
-
-            <div className="level-item is-blue">
-              <h5 className="heading"> </h5>
-              <h1>
-                {casesMap[0].cases - casesMap[1].cases > 0
-                  ? upArrow
-                  : downArrow}
-                {Math.abs(casesMap[0].cases - casesMap[1].cases)}*
-              </h1>
-              <h1 className="title has-text-grey">{}</h1>
-            </div>
-
-            <div className="level-item is-blue">
-              <h5>{casesMap[0].date}</h5>
-              <h2> {casesMap[0].cases}* </h2>
-            </div>
+            {(function () {
+              const rows = [];
+              for (let index = casesMap.length - 1; index > 0; index--) {
+                rows.push(
+                  <React.Fragment>
+                    {index < casesMap.length - 1 && (
+                      <div
+                        className={`level-item ${
+                          casesMap[index - 1].cases - casesMap[index].cases < 0
+                            ? casesMap[index - 1].date == 'Today'
+                              ? 'is-blue'
+                              : 'is-green'
+                            : 'is-cherry'
+                        }`}
+                      >
+                        <h5 className="heading"> </h5>
+                        <h1>
+                          {casesMap[index - 1].cases - casesMap[index].cases > 0
+                            ? upArrow
+                            : downArrow}
+                          {Math.abs(
+                            casesMap[index - 1].cases - casesMap[index].cases
+                          )}
+                        </h1>
+                        <h1 className="title has-text-grey">{}</h1>
+                      </div>
+                    )}
+                    <div
+                      className={`level-item ${
+                        casesMap[index - 1].cases - casesMap[index].cases < 0
+                          ? casesMap[index - 1].date == 'Today'
+                            ? 'is-blue'
+                            : 'is-green'
+                          : 'is-cherry'
+                      }`}
+                    >
+                      <h5 className="heading">{casesMap[index - 1].date}</h5>
+                      <h2 className="title has-text-grey">
+                        {casesMap[index - 1].cases}
+                      </h2>
+                    </div>
+                  </React.Fragment>
+                );
+              }
+              return rows;
+            })()}
           </div>
         </React.Fragment>
       )}

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -1,0 +1,110 @@
+import React, {useState, useEffect} from 'react';
+
+function RateOfNewCases(props) {
+  const [yesterdayCases, setYesterdayCases] = useState(0);
+  const [secondLastDayCases, setSecondLastDayCases] = useState(0);
+  const [secondLastDayDate, setSecondLastDayDate] = useState(0);
+  const [thirdLastDayCases, setThirdLastDayCases] = useState(0);
+  const [fourthLastDayCases, setFourthLastDayCases] = useState(0);
+  const [thirdLastDayDate, setThirdLastDayDate] = useState(0);
+
+  useEffect(() => {
+    parseData();
+  });
+
+  const parseData = () => {
+    const length = props.timeseries.length;
+    if (length > 0) {
+      setYesterdayCases(props.timeseries[length - 1]['dailyconfirmed']);
+      setSecondLastDayCases(props.timeseries[length - 2]['dailyconfirmed']);
+      setSecondLastDayDate(props.timeseries[length - 2]['date']);
+      setThirdLastDayCases(props.timeseries[length - 3]['dailyconfirmed']);
+      setThirdLastDayDate(props.timeseries[length - 3]['date']);
+      setFourthLastDayCases(props.timeseries[length - 4]['dailyconfirmed']);
+    }
+  };
+
+  return (
+    <div className="home-left">
+      <h2 className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
+        Rate of New Cases
+      </h2>
+      <div className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
+        <div
+          className={`level-item ${
+            thirdLastDayCases - fourthLastDayCases < 0
+              ? 'is-green'
+              : 'is-cherry'
+          }`}
+        >
+          <h5 className="heading">{thirdLastDayDate}</h5>
+          <h2 className="title has-text-grey">{thirdLastDayCases}</h2>
+        </div>
+
+        <div
+          className={`level-item ${
+            secondLastDayCases - thirdLastDayCases < 0
+              ? 'is-green'
+              : 'is-cherry'
+          }`}
+        >
+          <h5 className="heading"> </h5>
+          <h1>
+            {(secondLastDayCases - thirdLastDayCases > 0 ? '+' : '') +
+              (secondLastDayCases - thirdLastDayCases)}
+          </h1>
+          <h1 className="title has-text-grey">{}</h1>
+        </div>
+
+        <div
+          className={`level-item ${
+            secondLastDayCases - thirdLastDayCases < 0
+              ? 'is-green'
+              : 'is-cherry'
+          }`}
+        >
+          <h5 className="heading">{secondLastDayDate}</h5>
+          <h2 className="title has-text-success">{secondLastDayCases} </h2>
+        </div>
+
+        <div
+          className={`level-item ${
+            yesterdayCases - secondLastDayCases < 0 ? 'is-green' : 'is-cherry'
+          }`}
+        >
+          <h5 className="heading has-text-info">{} </h5>
+          <h1 className="has-text-info">
+            {(yesterdayCases - secondLastDayCases > 0 ? '+' : '') +
+              (yesterdayCases - secondLastDayCases)}
+          </h1>
+          <h1 className="title has-text-grey">{}</h1>
+        </div>
+
+        <div
+          className={`level-item ${
+            yesterdayCases - secondLastDayCases < 0 ? 'is-green' : 'is-cherry'
+          }`}
+        >
+          <h5 className="heading">Yesterday</h5>
+          <h2 className="title has-text-info">{yesterdayCases}</h2>
+        </div>
+
+        <div className="level-item is-blue">
+          <h5 className="heading"> </h5>
+          <h1>
+            {(props.deltas.confirmeddelta - yesterdayCases > 0 ? '+' : '') +
+              (props.deltas.confirmeddelta - yesterdayCases)}
+          </h1>
+          <h1 className="title has-text-grey">{}</h1>
+        </div>
+
+        <div className="level-item is-blue">
+          <h5>Today</h5>
+          <h2> {props.deltas.confirmeddelta}* </h2>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default RateOfNewCases;

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -2,6 +2,7 @@ import React, {useState, useEffect} from 'react';
 
 function RateOfNewCases(props) {
   const [yesterdayCases, setYesterdayCases] = useState(0);
+  const [todayCases, setTodayCases] = useState(0);
   const [secondLastDayCases, setSecondLastDayCases] = useState(0);
   const [secondLastDayDate, setSecondLastDayDate] = useState(0);
   const [thirdLastDayCases, setThirdLastDayCases] = useState(0);
@@ -21,6 +22,7 @@ function RateOfNewCases(props) {
       setThirdLastDayCases(props.timeseries[length - 3]['dailyconfirmed']);
       setThirdLastDayDate(props.timeseries[length - 3]['date']);
       setFourthLastDayCases(props.timeseries[length - 4]['dailyconfirmed']);
+      setTodayCases(props.deltas.confirmeddelta);
     }
   };
 
@@ -50,8 +52,10 @@ function RateOfNewCases(props) {
         >
           <h5 className="heading"> </h5>
           <h1>
-            {(secondLastDayCases - thirdLastDayCases > 0 ? '+' : '') +
-              (secondLastDayCases - thirdLastDayCases)}
+            {secondLastDayCases - thirdLastDayCases > 0
+              ? String.fromCharCode(8593)
+              : String.fromCharCode(8595)}
+            {Math.abs(secondLastDayCases - thirdLastDayCases)}
           </h1>
           <h1 className="title has-text-grey">{}</h1>
         </div>
@@ -74,8 +78,10 @@ function RateOfNewCases(props) {
         >
           <h5 className="heading has-text-info">{} </h5>
           <h1 className="has-text-info">
-            {(yesterdayCases - secondLastDayCases > 0 ? '+' : '') +
-              (yesterdayCases - secondLastDayCases)}
+            {yesterdayCases - secondLastDayCases > 0
+              ? String.fromCharCode(8593)
+              : String.fromCharCode(8595)}
+            {Math.abs(yesterdayCases - secondLastDayCases)}
           </h1>
           <h1 className="title has-text-grey">{}</h1>
         </div>
@@ -92,15 +98,17 @@ function RateOfNewCases(props) {
         <div className="level-item is-blue">
           <h5 className="heading"> </h5>
           <h1>
-            {(props.deltas.confirmeddelta - yesterdayCases > 0 ? '+' : '') +
-              (props.deltas.confirmeddelta - yesterdayCases)}
+            {todayCases - yesterdayCases > 0
+              ? String.fromCharCode(8593)
+              : String.fromCharCode(8595)}
+            {Math.abs(todayCases - yesterdayCases)}*
           </h1>
           <h1 className="title has-text-grey">{}</h1>
         </div>
 
         <div className="level-item is-blue">
           <h5>Today</h5>
-          <h2> {props.deltas.confirmeddelta}* </h2>
+          <h2> {todayCases}* </h2>
         </div>
       </div>
     </div>

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -42,14 +42,12 @@ function RateOfNewCases(props) {
   for (let index = casesMap.length - 1; index > 0; index--) {
     const casesDiff = casesMap[index - 1].cases - casesMap[index].cases;
     const isToday = casesMap[index - 1].date === 'Today';
+    const color =
+      casesDiff < 0 ? (isToday ? 'is-blue' : 'is-green') : 'is-cherry';
     rows.push(
       <React.Fragment key={index}>
         {index < casesMap.length - 1 && (
-          <div
-            className={`level-item ${
-              casesDiff < 0 ? (isToday ? 'is-blue' : 'is-green') : 'is-cherry'
-            }`}
-          >
+          <div className={`level-item ${color}`}>
             <h5 className="heading"> </h5>
             <h1>
               {casesDiff > 0 ? upArrow : downArrow}
@@ -59,11 +57,7 @@ function RateOfNewCases(props) {
             <h1 className="title has-text-grey"></h1>
           </div>
         )}
-        <div
-          className={`level-item ${
-            casesDiff < 0 ? (isToday ? 'is-blue' : 'is-green') : 'is-cherry'
-          }`}
-        >
+        <div className={`level-item ${color}`}>
           <h5 className="heading">{casesMap[index - 1].date}</h5>
           <h2 className="title has-text-grey">
             {casesMap[index - 1].cases}

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -70,14 +70,12 @@ function RateOfNewCases(props) {
 
   return (
     <div className="home-left">
-      <React.Fragment>
-        <h2 className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
-          Rate of New Cases
-        </h2>
-        <div className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
-          {rows}
-        </div>
-      </React.Fragment>
+      <h2 className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
+        Rate of New Cases
+      </h2>
+      <div className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
+        {rows}
+      </div>
     </div>
   );
 }

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -71,6 +71,7 @@ function RateOfNewCases(props) {
                           {Math.abs(
                             casesMap[index - 1].cases - casesMap[index].cases
                           )}
+                          {casesMap[index - 1].date == 'Today' ? '*' : ''}
                         </h1>
                         <h1 className="title has-text-grey">{}</h1>
                       </div>
@@ -87,6 +88,7 @@ function RateOfNewCases(props) {
                       <h5 className="heading">{casesMap[index - 1].date}</h5>
                       <h2 className="title has-text-grey">
                         {casesMap[index - 1].cases}
+                        {casesMap[index - 1].date == 'Today' ? '*' : ''}
                       </h2>
                     </div>
                   </React.Fragment>

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -1,36 +1,42 @@
 import React, {useState, useEffect} from 'react';
 
 function RateOfNewCases(props) {
-  const [firstDayCases, setFirstDayCases] = useState(0);
-  const [firstDayDate, setFirstDayDate] = useState(0);
-  const [secondDayCases, setSecondDayCases] = useState(0);
-  const [secondDayDate, setSecondDayDate] = useState(0);
-  const [thirdDayCases, setThirdDayCases] = useState(0);
-  const [thirdDayDate, setThirdDayDate] = useState(0);
-  const [fourthDayCases, setFourthDayCases] = useState(0);
-  const [fourthDayDate, setFourthDayDate] = useState(0);
-  const [fifthDayCases, setFifthDayCases] = useState(0);
-  const [upArrow, setUpArrow] = useState(0);
-  const [downArrow, setDownArrow] = useState(0);
+  const [casesMap, setCasesMap] = useState(0);
+  const [length, setLength] = useState(0);
+  const upArrow = String.fromCharCode(8593);
+  const downArrow = String.fromCharCode(8595);
 
   useEffect(() => {
     parseData();
-    setUpArrow(String.fromCharCode(8593));
-    setDownArrow(String.fromCharCode(8595));
   });
 
   const parseData = () => {
     const length = props.timeseries.length;
     if (length > 0) {
-      setFirstDayCases(props.deltas.confirmeddelta);
-      setFirstDayDate('Today');
-      setSecondDayCases(props.timeseries[length - 1]['dailyconfirmed']);
-      setSecondDayDate('Yesterday');
-      setThirdDayCases(props.timeseries[length - 2]['dailyconfirmed']);
-      setThirdDayDate(props.timeseries[length - 2]['date']);
-      setFourthDayCases(props.timeseries[length - 3]['dailyconfirmed']);
-      setFourthDayDate(props.timeseries[length - 3]['date']);
-      setFifthDayCases(props.timeseries[length - 4]['dailyconfirmed']);
+      const casesDetails = [
+        {
+          cases: props.deltas.confirmeddelta,
+          date: 'Today',
+        },
+        {
+          cases: props.timeseries[length - 1]['dailyconfirmed'],
+          date: 'Yesterday',
+        },
+        {
+          cases: props.timeseries[length - 2]['dailyconfirmed'],
+          date: props.timeseries[length - 2]['date'],
+        },
+        {
+          cases: props.timeseries[length - 3]['dailyconfirmed'],
+          date: props.timeseries[length - 3]['date'],
+        },
+        {
+          cases: props.timeseries[length - 4]['dailyconfirmed'],
+          date: props.timeseries[length - 4]['date'],
+        },
+      ];
+      setCasesMap(casesDetails);
+      setLength(length);
     }
   };
 
@@ -40,72 +46,92 @@ function RateOfNewCases(props) {
         Rate of New Cases
       </h2>
       <div className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
-        <div
-          className={`level-item ${
-            fourthDayCases - fifthDayCases < 0 ? 'is-green' : 'is-cherry'
-          }`}
-        >
-          <h5 className="heading">{fourthDayDate}</h5>
-          <h2 className="title has-text-grey">{fourthDayCases}</h2>
-        </div>
+        {length > 0 && (
+          <React.Fragment>
+            <div
+              className={`level-item ${
+                casesMap[3].cases - casesMap[4].cases < 0
+                  ? 'is-green'
+                  : 'is-cherry'
+              }`}
+            >
+              <h5 className="heading">{casesMap[3].date}</h5>
+              <h2 className="title has-text-grey">{casesMap[3].cases}</h2>
+            </div>
 
-        <div
-          className={`level-item ${
-            thirdDayCases - fourthDayCases < 0 ? 'is-green' : 'is-cherry'
-          }`}
-        >
-          <h5 className="heading"> </h5>
-          <h1>
-            {thirdDayCases - fourthDayCases > 0 ? upArrow : downArrow}
-            {Math.abs(thirdDayCases - fourthDayCases)}
-          </h1>
-          <h1 className="title has-text-grey">{}</h1>
-        </div>
+            <div
+              className={`level-item ${
+                casesMap[2].cases - casesMap[3].cases < 0
+                  ? 'is-green'
+                  : 'is-cherry'
+              }`}
+            >
+              <h5 className="heading"> </h5>
+              <h1>
+                {casesMap[2].cases - casesMap[3].cases > 0
+                  ? upArrow
+                  : downArrow}
+                {Math.abs(casesMap[2].cases - casesMap[3].cases)}
+              </h1>
+              <h1 className="title has-text-grey">{}</h1>
+            </div>
 
-        <div
-          className={`level-item ${
-            thirdDayCases - fourthDayCases < 0 ? 'is-green' : 'is-cherry'
-          }`}
-        >
-          <h5 className="heading">{thirdDayDate}</h5>
-          <h2 className="title has-text-success">{thirdDayCases} </h2>
-        </div>
+            <div
+              className={`level-item ${
+                casesMap[2].cases - casesMap[3].cases < 0
+                  ? 'is-green'
+                  : 'is-cherry'
+              }`}
+            >
+              <h5 className="heading">{casesMap[2].date}</h5>
+              <h2 className="title has-text-success">{casesMap[2].cases} </h2>
+            </div>
 
-        <div
-          className={`level-item ${
-            secondDayCases - thirdDayCases < 0 ? 'is-green' : 'is-cherry'
-          }`}
-        >
-          <h5 className="heading has-text-info">{} </h5>
-          <h1 className="has-text-info">
-            {secondDayCases - thirdDayCases > 0 ? upArrow : downArrow}
-            {Math.abs(secondDayCases - thirdDayCases)}
-          </h1>
-          <h1 className="title has-text-grey">{}</h1>
-        </div>
+            <div
+              className={`level-item ${
+                casesMap[1].cases - casesMap[2].cases < 0
+                  ? 'is-green'
+                  : 'is-cherry'
+              }`}
+            >
+              <h5 className="heading has-text-info">{} </h5>
+              <h1 className="has-text-info">
+                {casesMap[1].cases - casesMap[2].cases > 0
+                  ? upArrow
+                  : downArrow}
+                {Math.abs(casesMap[1].cases - casesMap[2].cases)}
+              </h1>
+              <h1 className="title has-text-grey">{}</h1>
+            </div>
 
-        <div
-          className={`level-item ${
-            secondDayCases - thirdDayCases < 0 ? 'is-green' : 'is-cherry'
-          }`}
-        >
-          <h5 className="heading">{secondDayDate}</h5>
-          <h2 className="title has-text-info">{secondDayCases}</h2>
-        </div>
+            <div
+              className={`level-item ${
+                casesMap[1].cases - casesMap[2].cases < 0
+                  ? 'is-green'
+                  : 'is-cherry'
+              }`}
+            >
+              <h5 className="heading">{casesMap[1].date}</h5>
+              <h2 className="title has-text-info">{casesMap[1].cases}</h2>
+            </div>
 
-        <div className="level-item is-blue">
-          <h5 className="heading"> </h5>
-          <h1>
-            {firstDayCases - secondDayCases > 0 ? upArrow : downArrow}
-            {Math.abs(firstDayCases - secondDayCases)}*
-          </h1>
-          <h1 className="title has-text-grey">{}</h1>
-        </div>
+            <div className="level-item is-blue">
+              <h5 className="heading"> </h5>
+              <h1>
+                {casesMap[0].cases - casesMap[1].cases > 0
+                  ? upArrow
+                  : downArrow}
+                {Math.abs(casesMap[0].cases - casesMap[1].cases)}*
+              </h1>
+              <h1 className="title has-text-grey">{}</h1>
+            </div>
 
-        <div className="level-item is-blue">
-          <h5>{firstDayDate}</h5>
-          <h2> {firstDayCases}* </h2>
-        </div>
+            <div className="level-item is-blue">
+              <h5>{casesMap[0].date}</h5>
+              <h2> {casesMap[0].cases}* </h2>
+            </div>
+          </React.Fragment>
+        )}
       </div>
     </div>
   );

--- a/src/components/newcases.js
+++ b/src/components/newcases.js
@@ -38,43 +38,40 @@ function RateOfNewCases(props) {
     }
   };
 
-  function displayRateOfNewCases() {
-    const rows = [];
-    for (let index = casesMap.length - 1; index > 0; index--) {
-      const casesDiff = casesMap[index - 1].cases - casesMap[index].cases;
-      const isToday = casesMap[index - 1].date === 'Today';
-      rows.push(
-        <React.Fragment key={index}>
-          {index < casesMap.length - 1 && (
-            <div
-              className={`level-item ${
-                casesDiff < 0 ? (isToday ? 'is-blue' : 'is-green') : 'is-cherry'
-              }`}
-            >
-              <h5 className="heading"> </h5>
-              <h1>
-                {casesDiff > 0 ? upArrow : downArrow}
-                {Math.abs(casesDiff)}
-                {isToday ? '*' : ''}
-              </h1>
-              <h1 className="title has-text-grey"></h1>
-            </div>
-          )}
+  const rows = [];
+  for (let index = casesMap.length - 1; index > 0; index--) {
+    const casesDiff = casesMap[index - 1].cases - casesMap[index].cases;
+    const isToday = casesMap[index - 1].date === 'Today';
+    rows.push(
+      <React.Fragment key={index}>
+        {index < casesMap.length - 1 && (
           <div
             className={`level-item ${
               casesDiff < 0 ? (isToday ? 'is-blue' : 'is-green') : 'is-cherry'
             }`}
           >
-            <h5 className="heading">{casesMap[index - 1].date}</h5>
-            <h2 className="title has-text-grey">
-              {casesMap[index - 1].cases}
+            <h5 className="heading"> </h5>
+            <h1>
+              {casesDiff > 0 ? upArrow : downArrow}
+              {Math.abs(casesDiff)}
               {isToday ? '*' : ''}
-            </h2>
+            </h1>
+            <h1 className="title has-text-grey"></h1>
           </div>
-        </React.Fragment>
-      );
-    }
-    return rows;
+        )}
+        <div
+          className={`level-item ${
+            casesDiff < 0 ? (isToday ? 'is-blue' : 'is-green') : 'is-cherry'
+          }`}
+        >
+          <h5 className="heading">{casesMap[index - 1].date}</h5>
+          <h2 className="title has-text-grey">
+            {casesMap[index - 1].cases}
+            {isToday ? '*' : ''}
+          </h2>
+        </div>
+      </React.Fragment>
+    );
   }
 
   return (
@@ -84,7 +81,7 @@ function RateOfNewCases(props) {
           Rate of New Cases
         </h2>
         <div className="Level fadeInUp" style={{animationDelay: '0.8s'}}>
-          {displayRateOfNewCases()}
+          {rows}
         </div>
       </React.Fragment>
     </div>


### PR DESCRIPTION
Currently users have to go through the graphs below carefully to understand the trends.
The current situation is best described not by the total no of new cases but by checking improvement or worsening in the count of new cases arising daily. 
The total no is going to rise but it is important that at some point of time the no of new cases arising daily reduce...  Negative rate gives `Hope` hence shown in `Green` where as positive rate will create awareness for people to take caution seriously hence shown in `Red`.  
<img width="588" alt="Screenshot 2020-03-30 at 12 15 43 AM" src="https://user-images.githubusercontent.com/60075170/77857545-c3a0cc00-721b-11ea-9f71-977d71af05ae.png">
It is the daily change numbers that should influence media analyst and concerned people visiting the website.
Hence seperate section is added for Comparison between past 4 days data and showing rate of new cases.

<img width="1274" alt="Screenshot 2020-03-30 at 12 15 11 AM" src="https://user-images.githubusercontent.com/60075170/77857559-dca97d00-721b-11ea-9d0e-fd7794ef19f5.png">

As per the discussions on https://github.com/covid19india/covid19india-react/issues/317 
This feature is desired among the visitors. @jeremyphilemon @someshkar 

I have tested this code on local including negative rate as well as positive rate with change in dates.

Today's data is shown in blue as it can't be classified as `Green` or `Red` until end of day.
