### PR TITLE
Fix the Ahmadabad spell

### DIFF
--- a/public/maps/gujarat.json
+++ b/public/maps/gujarat.json
@@ -2585,7 +2585,7 @@
             "dt_cen_cd": 7,
             "st_cen_cd": 24,
             "st_nm": "Gujarat",
-            "district": "Ahmedabad"
+            "district": "Ahmadabad"
           }
         },
         {

--- a/public/maps/gujarat.json
+++ b/public/maps/gujarat.json
@@ -2648,7 +2648,7 @@
             "dt_cen_cd": 1,
             "st_cen_cd": 24,
             "st_nm": "Gujarat",
-            "district": "Kutch"
+            "district": "Kachchh"
           }
         },
         {


### PR DESCRIPTION
Due to mismatch of spelling Ahmadabad in data and Ahmedabad in map.  Gujarat map is not showing Ahmadabad data.
I have set the same spelling as data for map, it should fix the issue. https://github.com/covid19india/covid19india-react/issues/346