### PR TITLE
Formatting ticks to prevent overflowing.

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -149,7 +149,7 @@ function TimeSeries(props) {
               .ticks(5)
               .tickPadding(5)
               .tickFormat((tick) => {
-                if (Math.floor(tick) === tick) return tick;
+                if (Math.floor(tick) === tick) return d3.format('~s')(tick);
               })
           );
 


### PR DESCRIPTION
This PR formats the tick value of the timeseries on the front page. This will prevent the need of padding changes in the future.

**Type of PR**
- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #439 

**Checklist**
- [ ] Compiles and passes lint tests
- [ ] Properly formatted
- [ ] Tested on desktop
- [ ] Tested on phone

**Screenshots**
![Screenshot from 2020-04-01 15-45-22](https://user-images.githubusercontent.com/843615/78126372-14890e00-7430-11ea-9015-42e432024ea1.png)
![Screenshot from 2020-04-01 15-45-44](https://user-images.githubusercontent.com/843615/78126381-16eb6800-7430-11ea-93a4-1a95a9dd8a82.png)
