### PR TITLE
fix: text colour on github button hover

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -286,7 +286,7 @@ h6 {
       span {
         display: inline-block;
         transition: color 0.2s ease-in-out;
-        
+
         &:hover {
           color: $gray;
         }
@@ -441,7 +441,7 @@ h6 {
   transition: all 0.2s ease-in-out;
 
   &:hover {
-    color: #8ffe09 !important;
+    color: #000 !important;
     background: $light !important;
   }
 }
@@ -1469,7 +1469,7 @@ footer {
         display: flex;
         flex-direction: column;
         & > * {
-          align-self: flex-end; 
+          align-self: flex-end;
         }
 
         h5 {


### PR DESCRIPTION
**Description of PR**
Currently, the text on the GitHub button in the footer is difficult to read on hover. This PR fixes that.

**Type of PR**
- [x] Bugfix
- [ ] New feature

**Checklist**
- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Before

![before](https://user-images.githubusercontent.com/7896438/78138347-60de4900-7444-11ea-8960-fda83b0376b6.gif)

After

![after](https://user-images.githubusercontent.com/7896438/78138353-650a6680-7444-11ea-927e-28b915ea14f2.gif)
