### PR TITLE
font load optimisation

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,5 +1,6 @@
 @font-face {
   font-family: 'Archia';
+  font-display: fallback;
   src: url('fonts/Archia/archia-thin-webfont.eot');
   src:
     url('fonts/Archia/archia-thin-webfont.eot?#iefix') format('embedded-opentype'),
@@ -12,6 +13,7 @@
 
 @font-face {
   font-family: 'Archia';
+  font-display: fallback;
   src: url('fonts/Archia/archia-light-webfont.eot');
   src:
     url('fonts/Archia/archia-light-webfont.eot?#iefix') format('embedded-opentype'),
@@ -24,6 +26,7 @@
 
 @font-face {
   font-family: 'Archia';
+  font-display: fallback;
   src: url('fonts/Archia/archia-regular-webfont.eot');
   src:
     url('fonts/Archia/archia-regular-webfont.eot?#iefix') format('embedded-opentype'),
@@ -36,6 +39,7 @@
 
 @font-face {
   font-family: 'Archia';
+  font-display: fallback;
   src: url('fonts/Archia/archia-medium-webfont.eot');
   src:
     url('fonts/Archia/archia-medium-webfont.eot?#iefix') format('embedded-opentype'),
@@ -48,6 +52,7 @@
 
 @font-face {
   font-family: 'Archia';
+  font-display: fallback;
   src: url('fonts/Archia/archia-semibold-webfont.eot');
   src:
     url('fonts/Archia/archia-semibold-webfont.eot?#iefix') format('embedded-opentype'),
@@ -60,6 +65,7 @@
 
 @font-face {
   font-family: 'Archia';
+  font-display: fallback;
   src: url('fonts/Archia/archia-bold-webfont.eot');
   src:
     url('fonts/Archia/archia-bold-webfont.eot?#iefix') format('embedded-opentype'),
@@ -286,7 +292,7 @@ h6 {
       span {
         display: inline-block;
         transition: color 0.2s ease-in-out;
-        
+
         &:hover {
           color: $gray;
         }
@@ -1469,7 +1475,7 @@ footer {
         display: flex;
         flex-direction: column;
         & > * {
-          align-self: flex-end; 
+          align-self: flex-end;
         }
 
         h5 {


### PR DESCRIPTION
**Description of PR**
I have added the font fallback strategy when users face issues while downloading the font. 

**Type of PR**
- [ ] Bugfix
- [x] New feature

**Relevant Issues**  
NA

**Checklist**
- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
<img width="1671" alt="Screenshot 2020-04-02 at 12 22 18 AM" src="https://user-images.githubusercontent.com/17268928/78175442-81c09180-7478-11ea-8722-406ddc71e9fb.png">

