### PR TITLE
fix:district hover not working for odd tr

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -637,7 +637,7 @@ table {
       cursor: pointer;
 
       &:hover {
-        background: $gray-hover;
+        background: $gray-hover !important;
       }
 
       &.divider {


### PR DESCRIPTION
**Description of PR**
Its a minor hover bug fix. Please check the screenshots section below to see before and after effects.
**Type of PR**
- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #...

**Checklist**
- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
Before the fix --->
![district-hover-minor-bug](https://user-images.githubusercontent.com/5888249/78216891-7ef58900-74d8-11ea-995c-deebd2b4c861.gif)

After the fix --->
![district-hover-fix](https://user-images.githubusercontent.com/5888249/78216896-8452d380-74d8-11ea-8aa5-962a743b7838.gif)
