### PR TITLE
Fix districts highlighting on transition

### DIFF
--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -208,10 +208,13 @@ function ChoroplethMap({
     })();
   }, [mapMeta.geoDataFile, statistic, renderData, ready]);
 
-  const highlightRegionInMap = (name, mapType) => {
-    const propertyField = propertyFieldMap[mapType];
+  const highlightRegionInMap = (name) => {
     const paths = d3.selectAll('.path-region');
     paths.classed('map-hover', (d, i, nodes) => {
+      const propertyField =
+        'district' in d.properties
+          ? propertyFieldMap['state']
+          : propertyFieldMap['country'];
       if (name === d.properties[propertyField]) {
         nodes[i].parentNode.appendChild(nodes[i]);
         return true;
@@ -221,8 +224,8 @@ function ChoroplethMap({
   };
 
   useEffect(() => {
-    highlightRegionInMap(selectedRegion, mapMeta.mapType);
-  }, [mapMeta.mapType, svgRenderCount, selectedRegion]);
+    highlightRegionInMap(selectedRegion);
+  }, [svgRenderCount, selectedRegion]);
 
   return (
     <div className="svg-parent">


### PR DESCRIPTION
**Description of PR**
Fixes the brief transition in which districts were highlighting.

**Type of PR**
- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #522 

**Checklist**
- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
Refer #522 