### PR TITLE
Modify Y-axis of trends

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -98,8 +98,14 @@ function TimeSeries(props) {
         // apply mode, logMode, etc -- determine scales once and for all
         const applyLogMode = (maxY) =>
           logMode && logCharts.has(type)
-            ? d3.scaleLog().domain([1, maxY]).nice()
-            : d3.scaleLinear().domain([-maxY / 10, maxY]);
+            ? d3
+                .scaleLog()
+                .domain([1, 1.1 * maxY])
+                .nice()
+            : d3
+                .scaleLinear()
+                .domain([0, 1.1 * maxY])
+                .nice();
 
         return (mode
           ? applyLogMode(
@@ -113,9 +119,11 @@ function TimeSeries(props) {
 
       const y = (dataTypeIdx, day) => {
         // Scaling mode filters
-        const y = yScales[dataTypeIdx];
+        const scale = yScales[dataTypeIdx];
         const dType = dataTypes[dataTypeIdx];
-        return y(logMode ? Math.max(1, day[dType]) : day[dType]); // max(1,y) for logmode
+        return scale(
+          logMode && logCharts.has(dType) ? Math.max(1, day[dType]) : day[dType]
+        ); // max(1,y) for logmode
       };
 
       /* Focus dots */
@@ -155,7 +163,8 @@ function TimeSeries(props) {
       }
 
       const tickCount = (scaleIdx) => {
-        return logMode
+        const dType = dataTypes[scaleIdx];
+        return logMode && logCharts.has(dType)
           ? Math.ceil(Math.log10(yScales[scaleIdx].domain()[1]))
           : 5;
       };
@@ -177,7 +186,7 @@ function TimeSeries(props) {
               .axisRight(yScales[i])
               .ticks(tickCount(i))
               .tickPadding(5)
-              .tickFormat(d3.format('.2s'))
+              .tickFormat(d3.format('~s'))
           );
 
         /* Focus dots */


### PR DESCRIPTION
**Description of PR**
Small fixes related to trends axes:
- Remove buffer space above x-axis
- Add buffer space above max y value
- Remove trailing zeros from labels
- Fix log mode causing axis of daily trends to change

**Type of PR**
- [x] Bugfix
- [ ] New feature

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![image](https://user-images.githubusercontent.com/27727946/78235841-da367400-74f6-11ea-9d87-abb36f6454b5.png)
