### PR TITLE
Fix: Add id for associated labels for Logarithmic Input for Accessibility

### DIFF
--- a/src/components/home.js
+++ b/src/components/home.js
@@ -146,6 +146,7 @@ function Home(props) {
                 >
                   <label htmlFor="timeseries-logmode">Logarithmic</label>
                   <input
+                    id="timeseries-logmode"
                     type="checkbox"
                     checked={graphOption === 1 && timeseriesLogMode}
                     className="switch"


### PR DESCRIPTION
**Description of PR**
Logarithmic Input was missing Id for the associated label based on the Lighthouse audit report.

**Type of PR**
Accessibility minor fix.

- [x] Bugfix
- [ ] New feature

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Reference**

https://web.dev/label/?utm_source=lighthouse&utm_medium=devtools
https://stackoverflow.com/questions/56083674/lighthouse-error-form-elements-do-not-have-associated-labels

**Screenshots**

Before Change:
![Before Change](https://user-images.githubusercontent.com/23227030/78262485-41b3ea00-751e-11ea-9a11-433284302193.png)

After Change:
![After Change](https://user-images.githubusercontent.com/23227030/78262510-4b3d5200-751e-11ea-9fa3-9264482dc940.png)
