### PR TITLE
Adding Last Updated On column for each state

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -235,15 +235,16 @@ h6 {
   .home-right {
     display: flex;
     flex-direction: column;
-    width: 30rem;
   }
 
   .home-left {
     margin-right: 2.5rem;
+    width: 35rem;
   }
 
   .home-right {
     margin-left: 2.5rem;
+    width: 30rem;
   }
 }
 
@@ -319,7 +320,7 @@ h6 {
   position: relative;
   display: flex;
   flex-direction: column;
-  width: 30rem;
+  width: 35rem;
   align-self: center;
   justify-content: space-between;
   padding-top: 2rem;
@@ -471,7 +472,7 @@ h6 {
   flex-direction: row;
   justify-content: space-between;
   align-self: center;
-  width: 30rem;
+  width: 35rem;
 
   .level-item {
     display: flex;
@@ -575,7 +576,7 @@ abbr {
 
 table {
   position: relative;
-  width: 30rem;
+  width: 35rem;
   align-self: center;
   font-family: 'archia';
   text-transform: uppercase;
@@ -1218,7 +1219,7 @@ table {
 }
 
 .Minigraph {
-  width: 30rem;
+  width: 35rem;
   align-self: center;
   margin: 0;
   display: flex;

--- a/src/components/row.js
+++ b/src/components/row.js
@@ -141,11 +141,11 @@ function Row(props) {
         </td>
         <td>
           {isNaN(Date.parse(formatDate(state.lastupdatedtime)))
-                ? ''
-                : `${formatDistance(
-                    new Date(formatDate(state.lastupdatedtime)),
-                    new Date()
-                  )} Ago`}
+            ? ''
+            : `${formatDistance(
+                new Date(formatDate(state.lastupdatedtime)),
+                new Date()
+              )} Ago`}
         </td>
       </tr>
 

--- a/src/components/row.js
+++ b/src/components/row.js
@@ -139,6 +139,14 @@ function Row(props) {
           </span>*/}
           {parseInt(state.deaths) === 0 ? '-' : state.deaths}
         </td>
+        <td>
+          {isNaN(Date.parse(formatDate(state.lastupdatedtime)))
+                ? ''
+                : `${formatDistance(
+                    new Date(formatDate(state.lastupdatedtime)),
+                    new Date()
+                  )} Ago`}
+        </td>
       </tr>
 
       <tr

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -1,5 +1,6 @@
 import React, {useState, useEffect} from 'react';
 import {Link} from 'react-router-dom';
+import {formatDate} from '../utils/common-functions';
 
 import Row from './row';
 
@@ -53,7 +54,10 @@ function Table(props) {
       let value1 = StateData1[sortColumn];
       let value2 = StateData2[sortColumn];
 
-      if (sortColumn !== 'state') {
+      if (sortColumn === 'lastupdatedtime') {
+        value1 = Date.parse(formatDate(value1));
+        value2 = Date.parse(formatDate(value2));
+      } else if (sortColumn !== 'state') {
         value1 = parseInt(StateData1[sortColumn]);
         value2 = parseInt(StateData2[sortColumn]);
       }
@@ -228,6 +232,38 @@ function Table(props) {
                   style={{
                     display:
                       sortData.sortColumn === 'deaths' ? 'initial' : 'none',
+                  }}
+                >
+                  {sortData.isAscending ? (
+                    <div className="arrow-up" />
+                  ) : (
+                    <div className="arrow-down" />
+                  )}
+                </div>
+              </div>
+            </th>
+            <th className="sticky" onClick={(e) => handleSort(e, props)}>
+              <div className="heading-content">
+                <abbr
+                  style={{color:
+                    window.innerWidth <= 769 ? '#28a74599': ''}}
+                  title="LastUpdatedTime"
+                >
+                  {window.innerWidth <= 769
+                    ? window.innerWidth <= 375
+                      ? 'Lt Upd'
+                      : 'Last Uptd'
+                    : 'Last Updated'}
+                </abbr>
+                <div
+                  className={
+                    sortData.sortColumn === 'lastupdatedtime' ? 'sort-black' : ''
+                  }
+                ></div>
+                <div
+                  style={{
+                    display:
+                      sortData.sortColumn === 'lastupdatedtime' ? 'initial' : 'none',
                   }}
                 >
                   {sortData.isAscending ? (

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -245,8 +245,7 @@ function Table(props) {
             <th className="sticky" onClick={(e) => handleSort(e, props)}>
               <div className="heading-content">
                 <abbr
-                  style={{color:
-                    window.innerWidth <= 769 ? '#28a74599': ''}}
+                  style={{color: window.innerWidth <= 769 ? '#28a74599' : ''}}
                   title="LastUpdatedTime"
                 >
                   {window.innerWidth <= 769
@@ -257,13 +256,17 @@ function Table(props) {
                 </abbr>
                 <div
                   className={
-                    sortData.sortColumn === 'lastupdatedtime' ? 'sort-black' : ''
+                    sortData.sortColumn === 'lastupdatedtime'
+                      ? 'sort-black'
+                      : ''
                   }
                 ></div>
                 <div
                   style={{
                     display:
-                      sortData.sortColumn === 'lastupdatedtime' ? 'initial' : 'none',
+                      sortData.sortColumn === 'lastupdatedtime'
+                        ? 'initial'
+                        : 'none',
                   }}
                 >
                   {sortData.isAscending ? (


### PR DESCRIPTION
**Description of PR**
Adding new Last Updated On column after Deceased in states table to show it without expanding, with ability for sorting to show last updated state on top

**Type of PR**
- [ ] Bugfix
- [x] New feature

**Relevant Issues**  
Fixes #542 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [ ] Tested on phone

**Screenshots**
![image](https://user-images.githubusercontent.com/9803423/78297395-1694bf00-754d-11ea-8e63-732f50e1c7b6.png)
