### PR TITLE
Fixed modal overflow scrollbar and background scroll

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1796,7 +1796,7 @@ footer {
     background: #fff;
     width: 30rem;
     height: 40rem;
-    overflow-y: scroll;
+    overflow-y: auto;
     svg {
       width: 20px;
       stroke: $pblue-mid;

--- a/src/components/patients.js
+++ b/src/components/patients.js
@@ -12,6 +12,11 @@ function Patients(props) {
     setPatients(props.patients);
   }, [props.patients]);
 
+  useEffect(() => {
+    if (modal) document.body.style.overflow = 'hidden';
+    if (!modal) document.body.style.overflow = 'unset';
+  }, [modal]);
+
   const parseByDate = useCallback((patients) => {
     const log = {};
     for (let i = 0; i < patients.length; i++) {


### PR DESCRIPTION
Changed `overflow-y:scroll` to `overflow-y:auto` to remove scrollbar when not needed

**Screenshots**

**Before** 
![image](https://user-images.githubusercontent.com/31034782/78375156-054dc000-75ea-11ea-98c6-f326c6b75664.png)
**After**
![image](https://user-images.githubusercontent.com/31034782/78375184-0f6fbe80-75ea-11ea-8531-1c4b7e7f36a4.png)

