### PR TITLE
Adding Absolute last-updated date on hovering

### DIFF
--- a/src/components/home.js
+++ b/src/components/home.js
@@ -206,8 +206,8 @@ function Home(props) {
           </div>
         )}
       </div>
-    */}
       <div className="home-right"></div>
+    */}
     </div>
   );
 }

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -1,7 +1,7 @@
 import React, {useState, useEffect, useMemo, useCallback} from 'react';
 import ChoroplethMap from './choropleth';
 import {MAP_TYPES, MAPS_DIR} from '../constants';
-import {formatDate} from '../utils/common-functions';
+import {formatDate, formatDateAbsolute} from '../utils/common-functions';
 import {formatDistance} from 'date-fns';
 
 const mapMeta = {
@@ -425,7 +425,13 @@ export default function ({states, stateDistrictWiseData, regionHighlighted}) {
             }`}
           >
             <h6>Last Updated</h6>
-            <h3>
+            <h3
+              title={
+                isNaN(Date.parse(formatDate(lastupdatedtime)))
+                  ? ''
+                  : formatDateAbsolute(lastupdatedtime)
+              }
+            >
               {isNaN(Date.parse(formatDate(lastupdatedtime)))
                 ? ''
                 : formatDistance(

--- a/src/components/row.js
+++ b/src/components/row.js
@@ -1,6 +1,6 @@
 import React, {useState, useEffect, useCallback} from 'react';
 import * as Icon from 'react-feather';
-import {formatDate} from '../utils/common-functions';
+import {formatDate, formatDateAbsolute} from '../utils/common-functions';
 import {formatDistance} from 'date-fns';
 function Row(props) {
   const [state, setState] = useState(props.state);
@@ -148,7 +148,13 @@ function Row(props) {
         <td colSpan={2}>
           <div className="last-update">
             <h6>Last Updated&nbsp;</h6>
-            <h6>
+            <h6
+              title={
+                isNaN(Date.parse(formatDate(props.state.lastupdatedtime)))
+                  ? ''
+                  : formatDateAbsolute(props.state.lastupdatedtime)
+              }
+            >
               {isNaN(Date.parse(formatDate(props.state.lastupdatedtime)))
                 ? ''
                 : `${formatDistance(


### PR DESCRIPTION
**Description of PR**
* adding absolute last-updated time on-hover
* removing extra div(home-right) on home page

**Type of PR**
- [x] Bugfix
- [x] New feature

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone
