### PR TITLE
Region Highlight: Hovered region shold stay highlighted untill next h…

### DIFF
--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -82,16 +82,17 @@ function ChoroplethMap({
         .on('mouseover', (d) => {
           handleMouseover(d.properties[propertyField]);
           const target = d3.event.target;
+          d3.selectAll('.map-hover').attr('class', 'path-refion map-default');
           d3.select(target.parentNode.appendChild(target)).attr(
             'class',
             'map-hover'
           );
         })
-        .on('mouseleave', (d) => {
-          const target = d3.event.target;
-          d3.select(target).attr('class', 'path-region map-default');
-          if (onceTouchedRegion === d) onceTouchedRegion = null;
-        })
+        // .on('mouseleave', (d) => {
+        //   const target = d3.event.target;
+        //   d3.select(target).attr('class', 'path-region map-default');
+        //   if (onceTouchedRegion === d) onceTouchedRegion = null;
+        // })
         .on('touchstart', (d) => {
           if (onceTouchedRegion === d) onceTouchedRegion = null;
           else onceTouchedRegion = d;


### PR DESCRIPTION
…over.

Hovering on a region highlights the region. On mouse leave, this won't stay
highlighted even though the statistics about the region remains the same.

So highlight the region until statistics remain the same.

- [x] Bugfix

**Relevant Issues**  
Fixes #695



**Screenshots**
![Screenshot from 2020-04-05 18-39-08](https://user-images.githubusercontent.com/23723464/78499192-dd3a9a00-776c-11ea-8d3a-c7f308720163.png)
