### PR TITLE
Allow timeseries to be sliced by specific days

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2038,6 +2038,7 @@ select {
     text-align: center;
     font-weight: 800;
     transition: background 0.15s ease-in-out;
+    padding: 4px 10px;
 
     &.selected {
       background-color: #c9d6fb;

--- a/src/App.scss
+++ b/src/App.scss
@@ -2029,6 +2029,36 @@ select {
   }
 }
 
+.pills {
+  >button {
+    border: 1px solid #c9d6fb;
+    background-color: #edf1fe;
+    color: $blue;
+    text-transform: uppercase;
+    text-align: center;
+    font-weight: 800;
+    transition: background 0.15s ease-in-out;
+
+    &.selected {
+      background-color: #c9d6fb;
+    }
+
+    &:focus:not(:focus-visible) {
+      outline: none;
+    }
+
+    &:first-of-type {
+      border-top-left-radius: 5px;
+      border-bottom-left-radius: 5px;
+    }
+
+    &:last-of-type {
+      border-top-right-radius: 5px;
+      border-bottom-right-radius: 5px;
+    }
+  }
+}
+
 .legend {
   background: #fff;
   z-index: 101;

--- a/src/App.scss
+++ b/src/App.scss
@@ -2039,6 +2039,7 @@ select {
     font-weight: 800;
     transition: background 0.15s ease-in-out;
     padding: 4px 10px;
+    font-family: 'archia';
 
     &.selected {
       background-color: #c9d6fb;

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -3,7 +3,7 @@ import * as d3 from 'd3';
 import {lastDaysFromTimeseries} from '../utils/common-functions';
 
 function TimeSeries(props) {
-  const [timeseriesDays] = useState(Infinity);
+  const [timeseriesDays, setTimeseriesDays] = useState(Infinity);
   const [timeseries, setTimeseries] = useState([]);
   const [datapoint, setDatapoint] = useState({});
   const [index, setIndex] = useState(10);
@@ -502,6 +502,32 @@ function TimeSeries(props) {
             preserveAspectRatio="xMidYMid meet"
           />
         </div>
+      </div>
+
+      <div className="pills" style={{marginTop: '32px', textAlign: 'right'}}>
+        <button
+          type="button"
+          onClick={() => setTimeseriesDays(Infinity)}
+          className={timeseriesDays === Infinity ? 'selected' : ''}
+        >
+          All
+        </button>
+        <button
+          type="button"
+          onClick={() => setTimeseriesDays(30)}
+          className={timeseriesDays === 30 ? 'selected' : ''}
+          aria-label="1 month"
+        >
+          1M
+        </button>
+        <button
+          type="button"
+          onClick={() => setTimeseriesDays(7)}
+          className={timeseriesDays === 7 ? 'selected' : ''}
+          aria-label="7 days"
+        >
+          7D
+        </button>
       </div>
     </div>
   );

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -1,7 +1,9 @@
 import React, {useState, useEffect, useRef, useCallback} from 'react';
 import * as d3 from 'd3';
+import {lastDaysFromTimeseries} from '../utils/common-functions';
 
 function TimeSeries(props) {
+  const [timeseriesDays] = useState(Infinity);
   const [timeseries, setTimeseries] = useState([]);
   const [datapoint, setDatapoint] = useState({});
   const [index, setIndex] = useState(10);
@@ -18,9 +20,15 @@ function TimeSeries(props) {
 
   useEffect(() => {
     if (props.timeseries.length > 1) {
-      setTimeseries(props.timeseries);
+      const slicedTimeseries = lastDaysFromTimeseries(
+        props.timeseries,
+        timeseriesDays
+      );
+
+      setIndex(slicedTimeseries.length - 1);
+      setTimeseries(slicedTimeseries);
     }
-  }, [props.timeseries]);
+  }, [props.timeseries, timeseriesDays]);
 
   useEffect(() => {
     setMode(props.mode);

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -183,7 +183,7 @@ function TimeSeries(props) {
         s.append('g')
           .attr('transform', 'translate(0,' + height + ')')
           .attr('class', 'axis')
-          .call(d3.axisBottom(x));
+          .call(d3.axisBottom(x).ticks(7));
 
         /* Y axis */
         s.append('g')

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -276,7 +276,7 @@ function TimeSeries(props) {
     if (update > 0) {
       refreshGraphs();
     }
-  }, [update, refreshGraphs]);
+  }, [update, refreshGraphs, timeseries]);
 
   useEffect(() => {
     if (timeseries.length > 1) {

--- a/src/utils/common-functions.js
+++ b/src/utils/common-functions.js
@@ -47,3 +47,14 @@ export const validateCTS = (data = []) => {
       return new Date(d.date + year) < today;
     });
 };
+
+/**
+ * Returns the last `days` entries
+ * @param {Array<Object>} timeseries
+ * @param {number} days
+ *
+ * @return {Array<Object>}
+ */
+export function lastDaysFromTimeseries(timeseries, days) {
+  return timeseries.slice(timeseries.length - days);
+}


### PR DESCRIPTION
**Description of PR**
Allows the Spread Trends timeseries to be shown as the last 7 days, last 30 days, and since forever.

**Type of PR**

- [ ] Bugfix
- [x] New feature

**Relevant Issues**  
Fixes #629 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

![Desktop](https://user-images.githubusercontent.com/5698706/78514013-d5aadd80-77cc-11ea-8436-661fc82a049a.png)

![Mobile: Google Chrome on Android](https://user-images.githubusercontent.com/5698706/78514057-0be85d00-77cd-11ea-852a-1dc2b0e352b5.png)