### PR TITLE
Fix crash because of missing district data

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -252,7 +252,7 @@ function Table(props) {
                   total={false}
                   reveal={revealedStates[state.state]}
                   districts={
-                    Object.keys(districts).length - 1 > 0
+                    state.state in districts
                       ? districts[state.state].districtData
                       : []
                   }


### PR DESCRIPTION
**Description of PR**
Only adds district view of states for which district data is present. Better check to prevent crashes.

**Type of PR**
- [x] Bugfix
- [ ] New feature
