### PR TITLE
Add transition animations to charts

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -82,6 +82,7 @@ function TimeSeries(props) {
 
       const yScaleUniformLinear = d3
         .scaleLinear()
+        .clamp(true)
         .domain([0, yBuffer * d3.max(ts, (d) => d.totalconfirmed)])
         .nice()
         .range([chartHeight, margin.top]);
@@ -126,6 +127,7 @@ function TimeSeries(props) {
       const yScales = dataTypes.map((type) => {
         const yScaleLinear = d3
           .scaleLinear()
+          .clamp(true)
           .domain([0, yBuffer * d3.max(ts, (d) => d[type])])
           .nice()
           .range([chartHeight, margin.top]);

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -8,7 +8,6 @@ function TimeSeries(props) {
   const [index, setIndex] = useState(10);
   const [mode, setMode] = useState(props.mode);
   const [logMode, setLogMode] = useState(props.logMode);
-  const [update, setUpdate] = useState(-1);
   const [moving, setMoving] = useState(false);
 
   const graphElement1 = useRef(null);
@@ -26,12 +25,10 @@ function TimeSeries(props) {
 
   useEffect(() => {
     setMode(props.mode);
-    setUpdate((u) => u + 1);
   }, [props.mode]);
 
   useEffect(() => {
     setLogMode(props.logMode);
-    setUpdate((u) => u + 1);
   }, [props.logMode]);
 
   const graphData = useCallback(
@@ -260,26 +257,6 @@ function TimeSeries(props) {
     },
     [logMode, mode]
   );
-
-  const refreshGraphs = useCallback(() => {
-    const graphs = [
-      graphElement1,
-      graphElement2,
-      graphElement3,
-      graphElement4,
-      graphElement5,
-      graphElement6,
-    ];
-    for (let i = 0; i < graphs.length; i++) {
-      // d3.select(graphs[i].current).selectAll('*').remove();
-    }
-  }, []);
-
-  useEffect(() => {
-    if (update > 0) {
-      refreshGraphs();
-    }
-  }, [update, refreshGraphs]);
 
   useEffect(() => {
     if (timeseries.length > 1) {

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -51,8 +51,8 @@ function TimeSeries(props) {
 
       // Margins
       const margin = {top: 0, right: 25, bottom: 60, left: 20};
-      const width = 650 - margin.left - margin.right;
-      const height = 200 - margin.top - margin.bottom;
+      const chartWidth = 650 - margin.left - margin.right;
+      const chartHeight = 200 - margin.top - margin.bottom;
 
       const dateMin = new Date(ts[0]['date']);
       dateMin.setDate(dateMin.getDate() - 1);
@@ -62,12 +62,12 @@ function TimeSeries(props) {
       const x = d3
         .scaleTime()
         .domain([dateMin, dateMax])
-        .range([margin.left, width]);
+        .range([margin.left, chartWidth]);
 
       const indexScale = d3
         .scaleLinear()
         .domain([0, timeseries.length])
-        .range([margin.left, width]);
+        .range([margin.left, chartWidth]);
 
       // Arrays of objects
       const svgArray = [svg1, svg2, svg3, svg4, svg5, svg6];
@@ -118,7 +118,7 @@ function TimeSeries(props) {
                 : dTypeMaxMap['dailyconfirmed']
             )
           : applyLogMode(maxY)
-        ).range([height, margin.top]);
+        ).range([chartHeight, margin.top]);
       });
 
       const y = (dataTypeIdx, day) => {
@@ -176,13 +176,12 @@ function TimeSeries(props) {
       svgArray.forEach((s, i) => {
         /* X axis */
         s.append('g')
-          .attr('transform', 'translate(0,' + height + ')')
           .attr('class', 'axis')
-          .call(d3.axisBottom(x));
+          .call(d3.axisBottom(x))
+          .style('transform', `translateY(${chartHeight}px)`);
 
         /* Y axis */
         s.append('g')
-          .attr('transform', `translate(${width}, ${0})`)
           .attr('class', 'axis')
           .call(
             d3
@@ -190,7 +189,8 @@ function TimeSeries(props) {
               .ticks(tickCount(i))
               .tickPadding(5)
               .tickFormat(d3.format('~s'))
-          );
+          )
+          .style('transform', `translateX(${chartWidth}px)`);
 
         /* Focus dots */
         s.on('mousemove', mousemove)
@@ -233,7 +233,7 @@ function TimeSeries(props) {
             .enter()
             .append('line')
             .attr('x1', (d) => x(d['date']))
-            .attr('y1', height)
+            .attr('y1', chartHeight)
             .attr('x2', (d) => x(d['date']))
             .attr('y2', (d) => y(i, d))
             .style('stroke', colors[i] + '99')

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -35,6 +35,7 @@ function TimeSeries(props) {
     (timeseries) => {
       const ts = preprocessTimeseries(timeseries);
       const T = ts.length;
+      const yBuffer = 1.1;
 
       setDatapoint(timeseries[T - 1]);
       setIndex(T - 1);
@@ -81,20 +82,20 @@ function TimeSeries(props) {
 
       const yScaleUniformLinear = d3
         .scaleLinear()
-        .domain([0, d3.max(ts, (d) => d.totalconfirmed)])
+        .domain([0, yBuffer * d3.max(ts, (d) => d.totalconfirmed)])
         .nice()
         .range([chartHeight, margin.top]);
 
       const yScaleUniformLog = d3
         .scaleLog()
         .clamp(true)
-        .domain([1, d3.max(ts, (d) => d.totalconfirmed)])
+        .domain([1, yBuffer * d3.max(ts, (d) => d.totalconfirmed)])
         .nice()
         .range([chartHeight, margin.top]);
 
       const yScaleDailyUniform = d3
         .scaleLinear()
-        .domain([0, d3.max(ts, (d) => d.dailyconfirmed)])
+        .domain([0, yBuffer * d3.max(ts, (d) => d.dailyconfirmed)])
         .nice()
         .range([chartHeight, margin.top]);
 
@@ -132,19 +133,19 @@ function TimeSeries(props) {
 
         const yScaleLinear = d3
           .scaleLinear()
-          .domain([0, d3.max(ts, (d) => d[type])])
-          .nice()
-          .range([chartHeight, margin.top]);
-
-        const yScaleLog = d3
-          .scaleLog()
-          .clamp(true)
-          .domain([1, d3.max(ts, (d) => d[type])])
+          .domain([0, yBuffer * d3.max(ts, (d) => d[type])])
           .nice()
           .range([chartHeight, margin.top]);
 
         let y;
+        let yScaleLog;
         if (logCharts.has(type)) {
+          yScaleLog = d3
+            .scaleLog()
+            .clamp(true)
+            .domain([1, yBuffer * d3.max(ts, (d) => d[type])])
+            .nice()
+            .range([chartHeight, margin.top]);
           if (logMode) y = mode ? yScaleUniformLog : yScaleLog;
           else y = mode ? yScaleUniformLinear : yScaleLinear;
         } else {

--- a/src/utils/common-functions.js
+++ b/src/utils/common-functions.js
@@ -47,3 +47,15 @@ export const validateCTS = (data = []) => {
       return new Date(d.date + year) < today;
     });
 };
+
+export const preprocessTimeseries = (timeseries) => {
+  return timeseries.map((stat) => ({
+    date: new Date(stat.date + ' 2020'),
+    totalconfirmed: +stat.totalconfirmed,
+    totalrecovered: +stat.totalrecovered,
+    totaldeceased: +stat.totaldeceased,
+    dailyconfirmed: +stat.dailyconfirmed,
+    dailyrecovered: +stat.dailyrecovered,
+    dailydeceased: +stat.dailydeceased,
+  }));
+};


### PR DESCRIPTION
**Description of PR**
Added d3 transitions to all charts
- Refactored timeseries.js and added transitions to all charts
- Removed obsolete code

Transitions give a feel of what's happening when you toggle the switches.

**Type of PR**

- [ ] Bugfix
- [x] New feature

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Peek 2020-04-06 17-31](https://user-images.githubusercontent.com/27727946/78556372-81cfe100-782c-11ea-9eab-64535f0ceb29.gif)

**PS:** Right now, the focus dots can be interrupted mid-transition by mouse events. Can't seem to find a way to prevent this from happening in d3. Any help is appreciated.