### PR TITLE
Further modifications to trend charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "homepage": "http://covid19india.github.io/",
   "dependencies": {
+    "@juggle/resize-observer": "^3.1.3",
     "axios": "^0.19.2",
     "chart.js": "^2.9.3",
     "d3": "^5.15.0",

--- a/src/App.scss
+++ b/src/App.scss
@@ -2473,11 +2473,6 @@ select {
   .timeseries {
     .svg-parent {
       width: 100%;
-      svg {
-        text {
-          font-size: 0.95rem;
-        }
-      }
     }
   }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -300,7 +300,7 @@ h6 {
       span {
         display: inline-block;
         transition: color 0.2s ease-in-out;
-        
+
         &:hover {
           color: $gray;
         }
@@ -694,7 +694,7 @@ table {
         }
       }
     }
-	
+
     .table__count-text {
       margin-left: 0.25rem;
     }
@@ -779,7 +779,7 @@ table {
       background: $gray-hover;
     }
   }
-  
+
 	.table__title-wrapper {
 		position: relative;
 	}
@@ -1069,7 +1069,7 @@ table {
     margin-left: 1rem;
     display: flex;
     flex-direction: row;
-    
+
     label{
       font-size: 0.75rem;
       margin-right: 0.2rem;
@@ -1177,8 +1177,8 @@ input.switch:checked::after {
     }
 
     &.is-green {
-      h5 { 
-        color: $green-mid; 
+      h5 {
+        color: $green-mid;
         &.title {
           color: $green;
         }
@@ -1189,8 +1189,8 @@ input.switch:checked::after {
     }
 
     &.is-gray {
-      h5 { 
-        color: $gray-mid; 
+      h5 {
+        color: $gray-mid;
         &.title {
           color: $gray;
         }
@@ -1219,11 +1219,12 @@ input.switch:checked::after {
     height: 10rem;
 
     svg {
+      width: 100%;
       .domain,
       .tick,
       line {
         stroke: $cherry;
-        stroke-width: 2;
+        stroke-width: 1.5;
       }
 
       text {
@@ -1231,7 +1232,7 @@ input.switch:checked::after {
         text-transform: uppercase;
         color: $cherry-mid;
         stroke: transparent;
-        font-size: 12px;
+        font-size: 9px;
         font-weight: 600;
       }
     }
@@ -1774,7 +1775,7 @@ footer {
         }
       }
     }
-    
+
     &.age1-9 {
       background: #006400;
     }
@@ -1875,7 +1876,7 @@ footer {
         display: flex;
         flex-direction: column;
         & > * {
-          align-self: flex-end; 
+          align-self: flex-end;
         }
 
         h5 {
@@ -2057,7 +2058,7 @@ footer {
     font-weight: 600;
   }
 
-  .summary { 
+  .summary {
     flex-direction: row-reverse;
     flex-wrap: wrap-reverse
   }
@@ -2160,6 +2161,7 @@ select {
 }
 
 .pills {
+  text-align: right;
   >button {
     border: 1px solid #c9d6fb;
     background-color: #edf1fe;
@@ -2412,7 +2414,7 @@ select {
     }
   }
 }
-  
+
 
 @media (max-width: 769px) {
   .TimeSeries,

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -7,7 +7,9 @@ import {
 import {useResizeObserver} from '../utils/hooks';
 
 function TimeSeries(props) {
-  const [lastDaysCount, setLastDaysCount] = useState(Infinity);
+  const [lastDaysCount, setLastDaysCount] = useState(
+    window.innerWidth > 769 ? Infinity : 30
+  );
   const [timeseries, setTimeseries] = useState([]);
   const [datapoint, setDatapoint] = useState({});
   const [index, setIndex] = useState(10);

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -8,7 +8,7 @@ import {useResizeObserver} from '../utils/hooks';
 
 function TimeSeries(props) {
   const [lastDaysCount, setLastDaysCount] = useState(
-    window.innerWidth > 769 ? Infinity : 30
+    window.innerWidth > 512 ? Infinity : 30
   );
   const [timeseries, setTimeseries] = useState([]);
   const [datapoint, setDatapoint] = useState({});

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -77,6 +77,7 @@ function TimeSeries(props) {
 
       const xScale = d3
         .scaleTime()
+        .clamp(true)
         .domain([dateMin, dateMax])
         .range([margin.left, chartRight]);
 
@@ -168,6 +169,7 @@ function TimeSeries(props) {
       } else {
         const yScaleDailyUniform = d3
           .scaleLinear()
+          .clamp(true)
           .domain([0, yBuffer * d3.max(ts, (d) => d.dailyconfirmed)])
           .nice()
           .range([chartBottom, margin.top]);

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -4,6 +4,7 @@ import {
   preprocessTimeseries,
   sliceTimeseriesFromEnd,
 } from '../utils/common-functions';
+import {useResizeObserver} from '../utils/hooks';
 
 function TimeSeries(props) {
   const [lastDaysCount, setLastDaysCount] = useState(Infinity);
@@ -14,12 +15,15 @@ function TimeSeries(props) {
   const [logMode, setLogMode] = useState(props.logMode);
   const [moving, setMoving] = useState(false);
 
-  const graphElement1 = useRef(null);
-  const graphElement2 = useRef(null);
-  const graphElement3 = useRef(null);
-  const graphElement4 = useRef(null);
-  const graphElement5 = useRef(null);
-  const graphElement6 = useRef(null);
+  const svgRef1 = useRef();
+  const svgRef2 = useRef();
+  const svgRef3 = useRef();
+  const svgRef4 = useRef();
+  const svgRef5 = useRef();
+  const svgRef6 = useRef();
+
+  const wrapperRef = useRef();
+  const dimensions = useResizeObserver(wrapperRef);
 
   useEffect(() => {
     if (props.timeseries.length > 1) {
@@ -42,6 +46,8 @@ function TimeSeries(props) {
 
   const graphData = useCallback(
     (timeseries) => {
+      if (!dimensions) return;
+      console.log(dimensions);
       // Margins
       const margin = {top: 0, right: 40, bottom: 60, left: 35};
       const chartRight = 650 - margin.right;
@@ -54,12 +60,12 @@ function TimeSeries(props) {
       setDatapoint(timeseries[T - 1]);
       setIndex(T - 1);
 
-      const svg1 = d3.select(graphElement1.current);
-      const svg2 = d3.select(graphElement2.current);
-      const svg3 = d3.select(graphElement3.current);
-      const svg4 = d3.select(graphElement4.current);
-      const svg5 = d3.select(graphElement5.current);
-      const svg6 = d3.select(graphElement6.current);
+      const svg1 = d3.select(svgRef1.current);
+      const svg2 = d3.select(svgRef2.current);
+      const svg3 = d3.select(svgRef3.current);
+      const svg4 = d3.select(svgRef4.current);
+      const svg5 = d3.select(svgRef5.current);
+      const svg6 = d3.select(svgRef6.current);
 
       const dateMin = new Date(ts[0]['date']);
       dateMin.setDate(dateMin.getDate() - 1);
@@ -325,7 +331,7 @@ function TimeSeries(props) {
           .on('touchend', mouseout);
       });
     },
-    [logMode, mode]
+    [dimensions, logMode, mode]
   );
 
   useEffect(() => {
@@ -350,7 +356,7 @@ function TimeSeries(props) {
         className="timeseries"
         style={{display: props.type === 1 ? 'flex' : 'none'}}
       >
-        <div className="svg-parent">
+        <div className="svg-parent" ref={wrapperRef}>
           <div className="stats">
             <h5 className={`${!moving ? 'title' : ''}`}>Confirmed</h5>
             <h5 className={`${moving ? 'title' : ''}`}>
@@ -375,7 +381,7 @@ function TimeSeries(props) {
             </div>
           </div>
           <svg
-            ref={graphElement1}
+            ref={svgRef1}
             width="650"
             height="200"
             viewBox="0 0 650 200"
@@ -408,7 +414,7 @@ function TimeSeries(props) {
             </div>
           </div>
           <svg
-            ref={graphElement2}
+            ref={svgRef2}
             width="650"
             height="200"
             viewBox="0 0 650 200"
@@ -441,7 +447,7 @@ function TimeSeries(props) {
             </div>
           </div>
           <svg
-            ref={graphElement3}
+            ref={svgRef3}
             width="650"
             height="200"
             viewBox="0 0 650 200"
@@ -479,7 +485,7 @@ function TimeSeries(props) {
             </div>
           </div>
           <svg
-            ref={graphElement4}
+            ref={svgRef4}
             width="650"
             height="200"
             viewBox="0 0 650 200"
@@ -512,7 +518,7 @@ function TimeSeries(props) {
             </div>
           </div>
           <svg
-            ref={graphElement5}
+            ref={svgRef5}
             width="650"
             height="200"
             viewBox="0 0 650 200"
@@ -545,7 +551,7 @@ function TimeSeries(props) {
             </div>
           </div>
           <svg
-            ref={graphElement6}
+            ref={svgRef6}
             width="650"
             height="200"
             viewBox="0 0 650 200"

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -136,7 +136,7 @@ function TimeSeries(props) {
           .clamp(true)
           .domain([
             Math.max(1, uniformScaleMin),
-            yBuffer * d3.max(ts, (d) => d.totalconfirmed),
+            Math.max(1, yBuffer * d3.max(ts, (d) => d.totalconfirmed)),
           ])
           .nice()
           .range([chartBottom, margin.top]);
@@ -159,7 +159,7 @@ function TimeSeries(props) {
                 1,
                 d3.min(ts, (d) => d[type])
               ),
-              yBuffer * d3.max(ts, (d) => d[type]),
+              Math.max(1, yBuffer * d3.max(ts, (d) => d[type])),
             ])
             .nice()
             .range([chartBottom, margin.top]);

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -47,11 +47,13 @@ function TimeSeries(props) {
   const graphData = useCallback(
     (timeseries) => {
       if (!dimensions) return;
-      console.log(dimensions);
+      const width = dimensions.width;
+      const height = dimensions.height;
+
       // Margins
-      const margin = {top: 0, right: 40, bottom: 60, left: 35};
-      const chartRight = 650 - margin.right;
-      const chartBottom = 200 - margin.bottom;
+      const margin = {top: 15, right: 35, bottom: 30, left: 25};
+      const chartRight = width - margin.right;
+      const chartBottom = height - margin.bottom;
 
       const ts = preprocessTimeseries(timeseries);
       const T = ts.length;
@@ -77,10 +79,13 @@ function TimeSeries(props) {
         .domain([dateMin, dateMax])
         .range([margin.left, chartRight]);
 
+      // Number of x-axis ticks
+      const numTicksX = width < 480 ? 4 : 8;
+
       const xAxis = (g) =>
         g
           .attr('class', 'x-axis')
-          .call(d3.axisBottom(xScale).ticks(8))
+          .call(d3.axisBottom(xScale).ticks(numTicksX))
           .style('transform', `translateY(${chartBottom}px)`);
 
       const yAxis = (g, yScale) =>
@@ -191,7 +196,7 @@ function TimeSeries(props) {
           .attr('class', 'focus')
           .attr('fill', colors[i])
           .attr('stroke', colors[i])
-          .attr('r', 5);
+          .attr('r', 4);
       });
 
       function mousemove() {
@@ -259,7 +264,7 @@ function TimeSeries(props) {
           .attr('class', 'dot')
           .attr('fill', color)
           .attr('stroke', color)
-          .attr('r', 3)
+          .attr('r', 2)
           .transition(t)
           .attr('cx', (d) => xScale(d.date))
           .attr('cy', (d) => yScale(d[type]));
@@ -278,7 +283,7 @@ function TimeSeries(props) {
             .attr('class', 'trend')
             .attr('fill', 'none')
             .attr('stroke', color + '99')
-            .attr('stroke-width', 5);
+            .attr('stroke-width', 4);
 
           // HACK
           // Path interpolation is non-trivial. Ideally, a custom path tween
@@ -380,13 +385,7 @@ function TimeSeries(props) {
               </h6>
             </div>
           </div>
-          <svg
-            ref={svgRef1}
-            width="650"
-            height="200"
-            viewBox="0 0 650 200"
-            preserveAspectRatio="xMidYMid meet"
-          />
+          <svg ref={svgRef1} preserveAspectRatio="xMidYMid meet" />
         </div>
 
         <div className="svg-parent is-green">
@@ -413,13 +412,7 @@ function TimeSeries(props) {
               </h6>
             </div>
           </div>
-          <svg
-            ref={svgRef2}
-            width="650"
-            height="200"
-            viewBox="0 0 650 200"
-            preserveAspectRatio="xMidYMid meet"
-          />
+          <svg ref={svgRef2} preserveAspectRatio="xMidYMid meet" />
         </div>
 
         <div className="svg-parent is-gray">
@@ -446,13 +439,7 @@ function TimeSeries(props) {
               </h6>
             </div>
           </div>
-          <svg
-            ref={svgRef3}
-            width="650"
-            height="200"
-            viewBox="0 0 650 200"
-            preserveAspectRatio="xMidYMid meet"
-          />
+          <svg ref={svgRef3} preserveAspectRatio="xMidYMid meet" />
         </div>
       </div>
 
@@ -484,13 +471,7 @@ function TimeSeries(props) {
               </h6>
             </div>
           </div>
-          <svg
-            ref={svgRef4}
-            width="650"
-            height="200"
-            viewBox="0 0 650 200"
-            preserveAspectRatio="xMidYMid meet"
-          />
+          <svg ref={svgRef4} preserveAspectRatio="xMidYMid meet" />
         </div>
 
         <div className="svg-parent is-green">
@@ -517,13 +498,7 @@ function TimeSeries(props) {
               </h6>
             </div>
           </div>
-          <svg
-            ref={svgRef5}
-            width="650"
-            height="200"
-            viewBox="0 0 650 200"
-            preserveAspectRatio="xMidYMid meet"
-          />
+          <svg ref={svgRef5} preserveAspectRatio="xMidYMid meet" />
         </div>
 
         <div className="svg-parent is-gray">
@@ -550,17 +525,11 @@ function TimeSeries(props) {
               </h6>
             </div>
           </div>
-          <svg
-            ref={svgRef6}
-            width="650"
-            height="200"
-            viewBox="0 0 650 200"
-            preserveAspectRatio="xMidYMid meet"
-          />
+          <svg ref={svgRef6} preserveAspectRatio="xMidYMid meet" />
         </div>
       </div>
 
-      <div className="pills" style={{marginTop: '32px', textAlign: 'right'}}>
+      <div className="pills">
         <button
           type="button"
           onClick={() => setLastDaysCount(Infinity)}

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -358,9 +358,9 @@ function TimeSeries(props) {
     lastDate.getMonth() === yesterdayDate.getMonth() &&
     lastDate.getDate() === yesterdayDate.getDate();
 
-  const chartKey1 = chartType ? 'totalconfirmed' : 'dailyconfirmed';
-  const chartKey2 = chartType ? 'totalrecovered' : 'dailyrecovered';
-  const chartKey3 = chartType ? 'totaldeceased' : 'dailydeceased';
+  const chartKey1 = chartType === 1 ? 'totalconfirmed' : 'dailyconfirmed';
+  const chartKey2 = chartType === 1 ? 'totalrecovered' : 'dailyrecovered';
+  const chartKey3 = chartType === 1 ? 'totaldeceased' : 'dailydeceased';
 
   return (
     <div

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -1,11 +1,12 @@
-import ResizeObserver from 'resize-observer-polyfill';
+import {useState, useEffect} from 'react';
+import {ResizeObserver} from '@juggle/resize-observer';
 
 export const useResizeObserver = (ref) => {
   const [dimensions, setDimensions] = useState(null);
   useEffect(() => {
     const observeTarget = ref.current;
-    const resizeObserver = new ResizeObserver((entries) => {
-      entries.forEach((entry) => {
+    const resizeObserver = new ResizeObserver((entries, observer) => {
+      entries.forEach((entry, index) => {
         setDimensions(entry.contentRect);
       });
     });

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -1,0 +1,18 @@
+import ResizeObserver from 'resize-observer-polyfill';
+
+export const useResizeObserver = (ref) => {
+  const [dimensions, setDimensions] = useState(null);
+  useEffect(() => {
+    const observeTarget = ref.current;
+    const resizeObserver = new ResizeObserver((entries) => {
+      entries.forEach((entry) => {
+        setDimensions(entry.contentRect);
+      });
+    });
+    resizeObserver.observe(observeTarget);
+    return () => {
+      resizeObserver.unobserve(observeTarget);
+    };
+  }, [ref]);
+  return dimensions;
+};


### PR DESCRIPTION
**Description of PR**
- Make the trend charts' SVG fully responsive by adding a custom resizeObserver hook. Fixes scaling issues in landscape orientation on mobile/tablets.
- Remove extra divs and SVG elements; draw total and daily charts on same elements
- Add a transition animation between total and daily charts

**Type of PR**

- [x] Bugfix
- [x] New feature

**Relevant Issues**
Fixes #792 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Peek 2020-04-07 22-35](https://user-images.githubusercontent.com/27727946/78698601-31d24680-7920-11ea-936c-9da06a19f54c.gif)

![Peek 2020-04-07 22-33](https://user-images.githubusercontent.com/27727946/78698595-2ed75600-7920-11ea-94e4-0139f1b33494.gif)