### PR TITLE
adds filters for city and district for select date in demographics

### DIFF
--- a/src/components/patientdb.js
+++ b/src/components/patientdb.js
@@ -218,6 +218,8 @@ function PatientDB(props) {
               {getSortedValues(
                 filterByObject(patients, {
                   detectedstate: filters.detectedstate,
+                  detectedcity: filters.detectedcity,
+                  detecteddistrict: filters.detecteddistrict,
                 }),
                 'dateannounced'
               ).map((date, index) => {


### PR DESCRIPTION
**Description of PR**
Filters the list of dates shown in the dates dropdown based on city and district as well.
**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #771 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
