### PR TITLE
Add option to display timeseries chart from day lockdown began

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -3,6 +3,7 @@ import * as d3 from 'd3';
 import {
   preprocessTimeseries,
   sliceTimeseriesFromEnd,
+  getDaysFromLockdown,
 } from '../utils/common-functions';
 
 function TimeSeries(props) {
@@ -334,6 +335,7 @@ function TimeSeries(props) {
     }
   }, [timeseries, graphData]);
 
+  const daysFromLockdown = getDaysFromLockdown();
   const yesterdayDate = new Date();
   yesterdayDate.setDate(yesterdayDate.getDate() - 1);
   const lastDate = new Date(datapoint['date'] + '2020');
@@ -577,6 +579,14 @@ function TimeSeries(props) {
           aria-label="14 days"
         >
           14D
+        </button>
+        <button
+          type="button"
+          onClick={() => setLastDaysCount(daysFromLockdown)}
+          className={lastDaysCount === daysFromLockdown ? 'selected' : ''}
+          aria-label="From Lockdown"
+        >
+          From Lockdown
         </button>
       </div>
     </div>

--- a/src/utils/common-functions.js
+++ b/src/utils/common-functions.js
@@ -53,6 +53,9 @@ const stateCodes = {
   PY: 'Puducherry',
 };
 
+// Date Lockdown was initiated - 25th March
+const lockdownDate = new Date(2020, 2, 25);
+
 export const getStateName = (code) => {
   return stateCodes[code.toUpperCase()];
 };
@@ -113,4 +116,11 @@ export const preprocessTimeseries = (timeseries) => {
  */
 export function sliceTimeseriesFromEnd(timeseries, days) {
   return timeseries.slice(timeseries.length - days);
+}
+
+export function getDaysFromLockdown() {
+  const today = new Date();
+  const diffTime = Math.abs(today - lockdownDate);
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  return diffDays;
 }


### PR DESCRIPTION
**Description of PR**
 New option in the time-series graph to plot data from the day the lockdown was initiated. i.e 25th March.

**Type of PR**

- [ ] Bugfix
- [X] New feature

**Relevant Issues**  
Fixes #...

**Checklist**

- [X] Compiles and passes lint tests
- [X] Properly formatted
- [X] Tested on desktop
- [X] Tested on phone

**Screenshots**
![covid_lockdown_ss_desktop](https://user-images.githubusercontent.com/10784159/78775654-31838b00-79b4-11ea-98dd-558bc383d0de.jpg)
![covid_lockdown_mobile_ss](https://user-images.githubusercontent.com/10784159/78775735-57109480-79b4-11ea-8f7e-b330ff65d74f.jpg)
