### PR TITLE
Resolved bug #804:Wrong Link of Sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1456,6 +1456,11 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@juggle/resize-observer": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.1.3.tgz",
+      "integrity": "sha512-y7qc6SzZBlSpx8hEDfV0S9Cx6goROX/vBhS2Ru1Q78Jp1FlCMbxp7UcAN90rLgB3X8DSMBgDFxcmoG/VfdAhFA=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/src/components/patients.js
+++ b/src/components/patients.js
@@ -368,14 +368,14 @@ function Patients(props) {
 
             <h5>Source 2</h5>
             <div className="link">
-              <a href={patient.source1} target="_noblank">
+              <a href={patient.source2} target="_noblank">
                 {patient.source2}
               </a>
             </div>
 
             <h5>Source 3</h5>
             <div className="link">
-              <a href={patient.source1} target="_noblank">
+              <a href={patient.source3} target="_noblank">
                 {patient.source3}
               </a>
             </div>


### PR DESCRIPTION
**Description of PR**
Resolved bug #804: using the proper link for source2 and source3 in demographics page popup

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #804 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
