### PR TITLE
corrected tamilnadu district name as per datasource

### DIFF
--- a/public/maps/tamil-nadu.json
+++ b/public/maps/tamil-nadu.json
@@ -1640,7 +1640,7 @@
             "dt_cen_cd": 26,
             "st_cen_cd": 33,
             "st_nm": "Tamil Nadu",
-            "district": "Thoothukudi"
+            "district": "Thoothukkudi"
           }
         },
         {


### PR DESCRIPTION
corrected district name to Thoothukkudi as per the Data source

**Description of PR**
This PR corrects tamilnadu district name in map json
**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #849 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [ ] Tested on phone

**Screenshots**
![image](https://user-images.githubusercontent.com/25223784/78903100-4f2a2080-7a98-11ea-8ada-17fc220ae386.png)
