### PR TITLE
Typo in District name

### DIFF
--- a/public/maps/maharashtra.json
+++ b/public/maps/maharashtra.json
@@ -5390,7 +5390,7 @@
           "type": "Polygon",
           "properties": {
             "dt_code": "522",
-            "district": "Ahmadnagar",
+            "district": "Ahmednagar",
             "st_nm": "Maharashtra",
             "st_code": "27",
             "year": "2011_c"


### PR DESCRIPTION
**Description of PR**
Typo in city name 'Ahmadnagar' #845
Correction: 'Ahmadnagar' to 'Ahmednagar' in public/maps/maharashtra.json

**Type of PR**

- [x ] Bugfix

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [ ] Tested on phone

**Screenshots**
