### PR TITLE
Make maps more responsive

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -564,8 +564,8 @@ h6 {
     #outlined-number {
       font-family: 'archia';
       font-size: 0.7rem !important;
-      font-weight: 400;    
-      font-family: 'archia';  
+      font-weight: 400;
+      font-family: 'archia';
       height: 0.1rem;
     }
   }
@@ -1201,7 +1201,7 @@ table {
     display: flex;
     flex-direction: row;
     width: 100%;
-    margin-top: 1rem;
+    margin-top: 4rem;
     overflow: hidden;
 
     svg {
@@ -1217,6 +1217,10 @@ table {
         font-size: 10px;
       }
     }
+  }
+
+  .legend {
+    margin-top: 0;
   }
 
   .back-button {
@@ -1264,8 +1268,9 @@ table {
 
     .unknown {
       position: absolute;
-      top: 5rem;
-      width: 5rem;
+      right: 0;
+      top: 3rem;
+      width: 9rem;
     }
   }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -1200,7 +1200,8 @@ table {
   .svg-parent {
     display: flex;
     flex-direction: row;
-    width: 100%;
+    width: 90%;
+    margin: auto;
     margin-top: 4rem;
     overflow: hidden;
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -1206,8 +1206,10 @@ table {
     flex-direction: row;
     width: 100%;
     margin-top: 1rem;
+    overflow: hidden;
 
     svg {
+      width: 100%;
       align-self: center;
 
       text {

--- a/src/App.scss
+++ b/src/App.scss
@@ -1175,10 +1175,6 @@ table {
   z-index: 11;
 }
 
-.map-default {
-  stroke: none;
-}
-
 .map-hover {
   stroke: #ff073a;
   stroke-width: 2;

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -24,11 +24,17 @@ function ChoroplethMap({
 
   const ready = useCallback(
     (geoData) => {
-      d3.selectAll('svg#chart > *').remove();
+      d3.selectAll('svg#chart > *').style('display', 'none');
       const propertyField = propertyFieldMap[mapMeta.mapType];
       const maxInterpolation = 0.8;
 
       const svg = d3.select(choroplethMap.current);
+      const mapSelection = svg.select(`.${mapMeta.graphObjectName}`);
+      if (!mapSelection.empty()) {
+        console.log('here');
+        mapSelection.style('display', 'block');
+        return;
+      }
 
       const handleMouseover = (name) => {
         try {
@@ -73,7 +79,7 @@ function ChoroplethMap({
 
       let onceTouchedRegion = null;
 
-      const g = svg.append('g');
+      const g = svg.append('g').attr('class', mapMeta.graphObjectName);
       g.append('g')
         .attr('class', 'states')
         .selectAll('path')
@@ -145,7 +151,7 @@ function ChoroplethMap({
             d3.mouse(svg.node())
           )
           .on('end', () => {
-            changeMap(d.properties[propertyField], mapMeta.mapType);
+            changeMap(d.properties[propertyField]);
           });
       }
 
@@ -169,9 +175,22 @@ function ChoroplethMap({
       }
 
       // Reset on clicking outside map
-      svg.on('click', () => reset(750));
+      svg.on('click', () => {
+        changeMap('India');
+        // svg
+        //   .call(
+        //     zoom.transform,
+        //     d3.zoomIdentity,
+        //   );
+        // reset(750);
+      })
+      svg
+        .call(
+          zoom.transform,
+          d3.zoomIdentity,
+        );
       // Reset zoom
-      reset(0);
+      // reset(0);
 
       /* LEGEND */
       d3.selectAll('svg#legend > *').remove();
@@ -180,6 +199,7 @@ function ChoroplethMap({
       const margin = {left: 0.05 * width, right: 0.2 * width};
       const barWidth = width - margin.left - margin.right;
       const heightLegend = +svgLegend.attr('height');
+      const numTicks = Math.min(6, statistic.maxConfirmed)
       svgLegend
         .append('g')
         .style('transform', `translateX(${margin.left}px)`)
@@ -189,9 +209,9 @@ function ChoroplethMap({
             title: 'Confirmed Cases',
             width: barWidth,
             height: 0.8 * heightLegend,
-            ticks: 6,
+            ticks: numTicks,
             tickFormat: function (d, i, n) {
-              return n[i + 1] ? d : d + '+';
+              if (Number.isInteger(d)) return n[i + 1] ? d : d + '+';
             },
           })
         );

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -101,7 +101,7 @@ function ChoroplethMap({
           })
           .on('mouseleave', (d) => {
             const target = d3.event.target;
-            d3.select(target).attr('class', 'path-region map-default');
+            d3.select(target).attr('class', 'path-region');
             if (onceTouchedRegion === d) onceTouchedRegion = null;
           })
           .on('touchstart', (d) => {
@@ -125,6 +125,7 @@ function ChoroplethMap({
           });
 
         g.append('path')
+          .attr('class', 'borders')
           .attr('stroke', '#ff073a20')
           .attr('fill', 'none')
           .attr('stroke-width', 2)
@@ -141,6 +142,9 @@ function ChoroplethMap({
       function clicked(d) {
         if (onceTouchedRegion) return;
         if (mapMeta.mapType === MAP_TYPES.STATE) return;
+        g.selectAll('.borders').style('opacity', 0);
+        g.selectAll('.path-region').style('opacity', 0);
+        console.log(g.selectAll('.path-region'));
         // Zoom
         const [[x0, y0], [x1, y1]] = path.bounds(d);
         d3.event.stopPropagation();
@@ -189,7 +193,11 @@ function ChoroplethMap({
         changeMap('India');
       });
       // Reset zoom
-      if (mapMeta.mapType === MAP_TYPES.COUNTRY) reset(750);
+      if (mapMeta.mapType === MAP_TYPES.COUNTRY) {
+        g.selectAll('.borders').style('opacity', 1);
+        g.selectAll('.path-region').style('opacity', 1);
+        reset(750);
+      }
 
       /* LEGEND */
       d3.selectAll('svg#legend > *').remove();

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -201,7 +201,7 @@ function ChoroplethMap({
         const margin = {left: 0.02 * width, right: 0.2 * width};
         const barWidth = width - margin.left - margin.right;
         const heightLegend = +svgLegend.attr('height');
-        const numTicks = Math.min(6, statistic.maxConfirmed);
+        const numTicks = Math.min(width > 400 ? 6 : 5, statistic.maxConfirmed);
         svgLegend
           .append('g')
           .style('transform', `translateX(${margin.left}px)`)

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -142,8 +142,11 @@ function ChoroplethMap({
       function clicked(d) {
         if (onceTouchedRegion) return;
         if (mapMeta.mapType === MAP_TYPES.STATE) return;
-        g.selectAll('.borders').style('opacity', 0);
-        g.selectAll('.path-region').style('opacity', 0);
+        g.selectAll('.borders').transition().duration(750).style('opacity', 0);
+        g.selectAll('.path-region')
+          .transition()
+          .duration(750)
+          .style('opacity', 0);
         console.log(g.selectAll('.path-region'));
         // Zoom
         const [[x0, y0], [x1, y1]] = path.bounds(d);
@@ -194,8 +197,11 @@ function ChoroplethMap({
       });
       // Reset zoom
       if (mapMeta.mapType === MAP_TYPES.COUNTRY) {
-        g.selectAll('.borders').style('opacity', 1);
-        g.selectAll('.path-region').style('opacity', 1);
+        g.selectAll('.borders').transition().duration(750).style('opacity', 1);
+        g.selectAll('.path-region')
+          .transition()
+          .duration(750)
+          .style('opacity', 1);
         reset(750);
       }
 

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -64,7 +64,7 @@ function ChoroplethMap({
 
       let onceTouchedRegion = null;
 
-      svg.on('click', reset);
+      svg.on('click', () => reset(750));
 
       const g = svg.append("g");
 
@@ -123,18 +123,6 @@ function ChoroplethMap({
           path(topojson.mesh(geoData, geoData.objects[mapMeta.graphObjectName]))
         );
 
-      const zoom = d3.zoom()
-          .scaleExtent([1, 8])
-          .on("zoom", zoomed);
-
-      function reset() {
-        svg.transition().duration(750).call(
-          zoom.transform,
-          d3.zoomIdentity,
-          d3.zoomTransform(svg.node()).invert([width / 2, height / 2])
-        );
-      }
-
       function clicked(d) {
         if (onceTouchedRegion) return;
         if (mapMeta.mapType === MAP_TYPES.STATE) return;
@@ -150,9 +138,20 @@ function ChoroplethMap({
           d3.mouse(svg.node())
         )
         .on('end', () => {
-          reset();
           changeMap(d.properties[propertyField], mapMeta.mapType);
         });
+      }
+
+      const zoom = d3.zoom()
+          .scaleExtent([1, 8])
+          .on("zoom", zoomed);
+
+      function reset(t) {
+        svg.transition().duration(t).call(
+          zoom.transform,
+          d3.zoomIdentity,
+          d3.zoomTransform(svg.node()).invert([width / 2, height / 2])
+        );
       }
 
       function zoomed() {
@@ -160,7 +159,7 @@ function ChoroplethMap({
         g.attr("transform", transform);
         g.attr("stroke-width", 1 / transform.k);
       }
-
+      reset(0);
     },
     [
       mapData,

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -196,27 +196,29 @@ function ChoroplethMap({
       /* LEGEND */
       const svgLegend = d3.select(choroplethLegend.current);
       svgLegend.selectAll('*').remove();
-      // Colorbar
-      const margin = {left: 0.02 * width, right: 0.2 * width};
-      const barWidth = width - margin.left - margin.right;
-      const heightLegend = +svgLegend.attr('height');
-      const numTicks = Math.min(6, statistic.maxConfirmed);
-      svgLegend
-        .append('g')
-        .style('transform', `translateX(${margin.left}px)`)
-        .append(() =>
-          legend({
-            color: colorScale,
-            title: 'Confirmed Cases',
-            width: barWidth,
-            height: 0.8 * heightLegend,
-            ticks: numTicks,
-            tickFormat: function (d, i, n) {
-              if (Number.isInteger(d)) return n[i + 1] ? d : d + '+';
-            },
-          })
-        );
-      svgLegend.attr('viewBox', `0 0 ${width} ${heightLegend}`);
+      if (statistic.maxConfirmed) {
+        // Colorbar
+        const margin = {left: 0.02 * width, right: 0.2 * width};
+        const barWidth = width - margin.left - margin.right;
+        const heightLegend = +svgLegend.attr('height');
+        const numTicks = Math.min(6, statistic.maxConfirmed);
+        svgLegend
+          .append('g')
+          .style('transform', `translateX(${margin.left}px)`)
+          .append(() =>
+            legend({
+              color: colorScale,
+              title: 'Confirmed Cases',
+              width: barWidth,
+              height: 0.8 * heightLegend,
+              ticks: numTicks,
+              tickFormat: function (d, i, n) {
+                if (Number.isInteger(d)) return n[i + 1] ? d : d + '+';
+              },
+            })
+          );
+        svgLegend.attr('viewBox', `0 0 ${width} ${heightLegend}`);
+      }
     },
     [
       mapData,

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -142,7 +142,9 @@ function ChoroplethMap({
         // Slowly fade away all the states except highlighted one
         const t = d3.transition().duration(500);
         g.selectAll('.borders').transition(t).style('opacity', 0);
-        g.selectAll('.path-region').transition(t).style('opacity', 0);
+        g.selectAll('.path-region:not(.map-hover)')
+          .transition(t)
+          .style('opacity', 0);
         // Zoom to click
         const [[x0, y0], [x1, y1]] = path.bounds(d);
         d3.event.stopPropagation();
@@ -273,8 +275,10 @@ function ChoroplethMap({
           ref={choroplethMap}
         ></svg>
       </div>
-
-      <div className="svg-parent fadeInUp" style={{animationDelay: '2.5s'}}>
+      <div
+        className="svg-parent legend fadeInUp"
+        style={{animationDelay: '2.5s'}}
+      >
         <svg
           id="legend"
           height="65"

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -85,15 +85,9 @@ function ChoroplethMap({
           .attr('pointer-events', 'all')
           .on('mouseover', (d) => {
             handleMouseover(d.properties[propertyField]);
-            const target = d3.event.target;
-            d3.select(target.parentNode.appendChild(target)).attr(
-              'class',
-              'map-hover'
-            );
           })
           .on('mouseleave', (d) => {
-            const target = d3.event.target;
-            d3.select(target).attr('class', 'path-region');
+            setSelectedRegion(null);
             if (onceTouchedRegion === d) onceTouchedRegion = null;
           })
           .on('touchstart', (d) => {
@@ -134,6 +128,7 @@ function ChoroplethMap({
       const handleMouseover = (name) => {
         try {
           setHoveredRegion(name, mapMeta);
+          setSelectedRegion(name);
         } catch (err) {
           console.log('err', err);
         }

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -24,17 +24,12 @@ function ChoroplethMap({
 
   const ready = useCallback(
     (geoData) => {
-      d3.selectAll('svg#chart > *').style('display', 'none');
       const propertyField = propertyFieldMap[mapMeta.mapType];
       const maxInterpolation = 0.8;
-
       const svg = d3.select(choroplethMap.current);
-      const mapSelection = svg.select(`.${mapMeta.graphObjectName}`);
-      if (!mapSelection.empty()) {
-        console.log('here');
-        mapSelection.style('display', 'block');
-        return;
-      }
+
+      // Hide all objects on map (don't delete to cache)
+      d3.selectAll('svg#chart > *').style('display', 'none');
 
       const handleMouseover = (name) => {
         try {
@@ -78,55 +73,70 @@ function ChoroplethMap({
         .nice();
 
       let onceTouchedRegion = null;
+      let g;
+      const mapSelection = svg.select(`.${mapMeta.graphObjectName}`);
+      if (mapSelection.empty()) {
+        g = svg.append('g').attr('class', mapMeta.graphObjectName);
+        g.append('g')
+          .attr('class', 'states')
+          .selectAll('path')
+          .data(topology.features)
+          .enter()
+          .append('path')
+          .attr('class', 'path-region')
+          .attr('fill', function (d) {
+            const n = parseInt(mapData[d.properties[propertyField]]) || 0;
+            const color = n === 0 ? '#ffffff' : colorScale(n);
+            return color;
+          })
+          .attr('d', path)
+          .attr('pointer-events', 'all')
+          .on('mouseover', (d) => {
+            handleMouseover(d.properties[propertyField]);
+            const target = d3.event.target;
+            d3.select(target.parentNode.appendChild(target)).attr(
+              'class',
+              'map-hover'
+            );
+          })
+          .on('mouseleave', (d) => {
+            const target = d3.event.target;
+            d3.select(target).attr('class', 'path-region map-default');
+            if (onceTouchedRegion === d) onceTouchedRegion = null;
+          })
+          .on('touchstart', (d) => {
+            if (onceTouchedRegion === d) onceTouchedRegion = null;
+            else onceTouchedRegion = d;
+          })
+          .on('click', clicked)
+          .style('cursor', 'pointer')
+          .append('title')
+          .text(function (d) {
+            const value = mapData[d.properties[propertyField]] || 0;
+            return (
+              Number(
+                parseFloat(100 * (value / (statistic.total || 0.001))).toFixed(
+                  2
+                )
+              ).toString() +
+              '% from ' +
+              toTitleCase(d.properties[propertyField])
+            );
+          });
 
-      const g = svg.append('g').attr('class', mapMeta.graphObjectName);
-      g.append('g')
-        .attr('class', 'states')
-        .selectAll('path')
-        .data(topology.features)
-        .enter()
-        .append('path')
-        .attr('class', 'path-region')
-        .attr('fill', function (d) {
-          const n = parseInt(mapData[d.properties[propertyField]]) || 0;
-          const color = n === 0 ? '#ffffff' : colorScale(n);
-          return color;
-        })
-        .attr('d', path)
-        .attr('pointer-events', 'all')
-        .on('mouseover', (d) => {
-          handleMouseover(d.properties[propertyField]);
-        })
-        .on('mouseleave', (d) => {
-          setSelectedRegion(null);
-          if (onceTouchedRegion === d) onceTouchedRegion = null;
-        })
-        .on('touchstart', (d) => {
-          if (onceTouchedRegion === d) onceTouchedRegion = null;
-          else onceTouchedRegion = d;
-        })
-        .on('click', clicked)
-        .style('cursor', 'pointer')
-        .append('title')
-        .text(function (d) {
-          const value = mapData[d.properties[propertyField]] || 0;
-          return (
-            Number(
-              parseFloat(100 * (value / (statistic.total || 0.001))).toFixed(2)
-            ).toString() +
-            '% from ' +
-            toTitleCase(d.properties[propertyField])
+        g.append('path')
+          .attr('stroke', '#ff073a20')
+          .attr('fill', 'none')
+          .attr('stroke-width', 2)
+          .attr(
+            'd',
+            path(
+              topojson.mesh(geoData, geoData.objects[mapMeta.graphObjectName])
+            )
           );
-        });
-
-      g.append('path')
-        .attr('stroke', '#ff073a20')
-        .attr('fill', 'none')
-        .attr('stroke-width', 2)
-        .attr(
-          'd',
-          path(topojson.mesh(geoData, geoData.objects[mapMeta.graphObjectName]))
-        );
+      } else {
+        g = mapSelection.style('display', 'block');
+      }
 
       function clicked(d) {
         if (onceTouchedRegion) return;
@@ -177,29 +187,18 @@ function ChoroplethMap({
       // Reset on clicking outside map
       svg.on('click', () => {
         changeMap('India');
-        // svg
-        //   .call(
-        //     zoom.transform,
-        //     d3.zoomIdentity,
-        //   );
-        // reset(750);
-      })
-      svg
-        .call(
-          zoom.transform,
-          d3.zoomIdentity,
-        );
+      });
       // Reset zoom
-      // reset(0);
+      if (mapMeta.mapType === MAP_TYPES.COUNTRY) reset(750);
 
       /* LEGEND */
       d3.selectAll('svg#legend > *').remove();
       const svgLegend = d3.select(choroplethLegend.current);
       // Colorbar
-      const margin = {left: 0.05 * width, right: 0.2 * width};
+      const margin = {left: 0.02 * width, right: 0.2 * width};
       const barWidth = width - margin.left - margin.right;
       const heightLegend = +svgLegend.attr('height');
-      const numTicks = Math.min(6, statistic.maxConfirmed)
+      const numTicks = Math.min(6, statistic.maxConfirmed);
       svgLegend
         .append('g')
         .style('transform', `translateX(${margin.left}px)`)

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -27,7 +27,7 @@ function Home(props) {
   const [timeseries, setTimeseries] = useState({});
   const [activeStateCode, setActiveStateCode] = useState('TT'); // TT -> India
   const [activityLog, setActivityLog] = useState([]);
-  const [timeseriesMode, setTimeseriesMode] = useState(true);
+  const [timeseriesMode, setTimeseriesMode] = useState(false);
   const [timeseriesLogMode, setTimeseriesLogMode] = useState(false);
   const [regionHighlighted, setRegionHighlighted] = useState(undefined);
 

--- a/src/components/legend.js
+++ b/src/components/legend.js
@@ -1,0 +1,152 @@
+/* Source: https://observablehq.com/@d3/color-legend */
+import * as d3 from 'd3';
+
+function legend({
+  color,
+  title,
+  tickSize = 6,
+  width = 320,
+  height = 44 + tickSize,
+  marginTop = 18,
+  marginRight = 0,
+  marginBottom = 16 + tickSize,
+  marginLeft = 0,
+  ticks = width / 64,
+  tickFormat,
+  tickValues
+} = {}) {
+
+  const svg = d3.create("svg")
+      .attr("width", width)
+      .attr("height", height)
+      .attr("viewBox", [0, 0, width, height])
+      .style("overflow", "visible")
+      .style("display", "block");
+
+  let tickAdjust = g => g.selectAll(".tick line")
+						.attr("y1", marginTop + marginBottom - height)
+						.attr("stroke", "#ffffff")
+						.attr("stroke-width", 2);
+  let x;
+
+  // Continuous
+  if (color.interpolate) {
+    const n = Math.min(color.domain().length, color.range().length);
+
+    x = color.copy().rangeRound(d3.quantize(d3.interpolate(marginLeft, width - marginRight), n));
+
+    svg.append("image")
+        .attr("x", marginLeft)
+        .attr("y", marginTop)
+        .attr("width", width - marginLeft - marginRight)
+        .attr("height", height - marginTop - marginBottom)
+        .attr("preserveAspectRatio", "none")
+        .attr("xlink:href", ramp(color.copy().domain(d3.quantize(d3.interpolate(0, 1), n))).toDataURL());
+  }
+
+  // Sequential
+  else if (color.interpolator) {
+    x = Object.assign(color.copy()
+        .interpolator(d3.interpolateRound(marginLeft, width - marginRight)),
+        {range() { return [marginLeft, width - marginRight]; }});
+
+    svg.append("image")
+        .attr("x", marginLeft)
+        .attr("y", marginTop)
+        .attr("width", width - marginLeft - marginRight)
+        .attr("height", height - marginTop - marginBottom)
+        .attr("preserveAspectRatio", "none")
+        .attr("xlink:href", ramp(color.interpolator()).toDataURL());
+
+    // scaleSequentialQuantile doesn’t implement ticks or tickFormat.
+    if (!x.ticks) {
+      if (tickValues === undefined) {
+        const n = Math.round(ticks + 1);
+        tickValues = d3.range(n).map(i => d3.quantile(color.domain(), i / (n - 1)));
+      }
+      if (typeof tickFormat !== "function") {
+        tickFormat = d3.format(tickFormat === undefined ? ",f" : tickFormat);
+      }
+    }
+  }
+
+  // Threshold
+  else if (color.invertExtent) {
+    const thresholds
+        = color.thresholds ? color.thresholds() // scaleQuantize
+        : color.quantiles ? color.quantiles() // scaleQuantile
+        : color.domain(); // scaleThreshold
+
+    const thresholdFormat
+        = tickFormat === undefined ? d => d
+        : typeof tickFormat === "string" ? d3.format(tickFormat)
+        : tickFormat;
+
+    x = d3.scaleLinear()
+        .domain([-1, color.range().length - 1])
+        .rangeRound([marginLeft, width - marginRight]);
+
+    svg.append("g")
+      .selectAll("rect")
+      .data(color.range())
+      .join("rect")
+        .attr("x", (d, i) => x(i - 1))
+        .attr("y", marginTop)
+        .attr("width", (d, i) => x(i) - x(i - 1))
+        .attr("height", height - marginTop - marginBottom)
+        .attr("fill", d => d);
+
+    tickValues = d3.range(thresholds.length);
+    tickFormat = i => thresholdFormat(thresholds[i], i);
+  }
+
+  // Ordinal
+  else {
+    x = d3.scaleBand()
+        .domain(color.domain())
+        .rangeRound([marginLeft, width - marginRight]);
+
+    svg.append("g")
+      .selectAll("rect")
+      .data(color.domain())
+      .join("rect")
+        .attr("x", x)
+        .attr("y", marginTop)
+        .attr("width", Math.max(0, x.bandwidth() - 1))
+        .attr("height", height - marginTop - marginBottom)
+        .attr("fill", color);
+
+    tickAdjust = () => {};
+  }
+
+  svg.append("g")
+      .attr("transform", `translate(0,${height - marginBottom})`)
+      .call(d3.axisBottom(x)
+        .ticks(ticks, typeof tickFormat === "string" ? tickFormat : undefined)
+        .tickFormat(typeof tickFormat === "function" ? tickFormat : undefined)
+        .tickSize(tickSize)
+        .tickValues(tickValues))
+      .call(tickAdjust)
+      .call(g => g.select(".domain").remove())
+      .call(g => g.append("text")
+        .attr("x", marginLeft)
+        .attr("y", marginTop + marginBottom - height - 6)
+        .attr("fill", "currentColor")
+        .attr("text-anchor", "start")
+        .attr("font-weight", "bold")
+        .text(title));
+
+  return svg.node();
+};
+
+function ramp(color, n = 256) {
+  const canvas = document.createElement("canvas");
+  const context = (canvas.width = n, canvas.height = 1, canvas).getContext("2d");
+  for (let i = 0; i < n; ++i) {
+    context.fillStyle = color(i / (n - 1));
+    context.fillRect(i, 0, 1, 1);
+  }
+  return canvas;
+}
+
+export default legend;

--- a/src/components/legend.js
+++ b/src/components/legend.js
@@ -13,135 +13,169 @@ function legend({
   marginLeft = 0,
   ticks = width / 64,
   tickFormat,
-  tickValues
+  tickValues,
 } = {}) {
+  const svg = d3
+    .create('svg')
+    .attr('width', width)
+    .attr('height', height)
+    .attr('viewBox', [0, 0, width, height])
+    .style('overflow', 'visible')
+    .style('display', 'block');
 
-  const svg = d3.create("svg")
-      .attr("width", width)
-      .attr("height", height)
-      .attr("viewBox", [0, 0, width, height])
-      .style("overflow", "visible")
-      .style("display", "block");
-
-  let tickAdjust = g => g.selectAll(".tick line")
-						.attr("y1", marginTop + marginBottom - height)
-						.attr("stroke", "#ffffff")
-						.attr("stroke-width", 2);
+  let tickAdjust = (g) =>
+    g.selectAll('.tick line').attr('y1', marginTop + marginBottom - height);
   let x;
 
   // Continuous
   if (color.interpolate) {
     const n = Math.min(color.domain().length, color.range().length);
 
-    x = color.copy().rangeRound(d3.quantize(d3.interpolate(marginLeft, width - marginRight), n));
+    x = color
+      .copy()
+      .rangeRound(
+        d3.quantize(d3.interpolate(marginLeft, width - marginRight), n)
+      );
 
-    svg.append("image")
-        .attr("x", marginLeft)
-        .attr("y", marginTop)
-        .attr("width", width - marginLeft - marginRight)
-        .attr("height", height - marginTop - marginBottom)
-        .attr("preserveAspectRatio", "none")
-        .attr("xlink:href", ramp(color.copy().domain(d3.quantize(d3.interpolate(0, 1), n))).toDataURL());
+    svg
+      .append('image')
+      .attr('x', marginLeft)
+      .attr('y', marginTop)
+      .attr('width', width - marginLeft - marginRight)
+      .attr('height', height - marginTop - marginBottom)
+      .attr('preserveAspectRatio', 'none')
+      .attr(
+        'xlink:href',
+        ramp(
+          color.copy().domain(d3.quantize(d3.interpolate(0, 1), n))
+        ).toDataURL()
+      );
   }
 
   // Sequential
   else if (color.interpolator) {
-    x = Object.assign(color.copy()
+    x = Object.assign(
+      color
+        .copy()
         .interpolator(d3.interpolateRound(marginLeft, width - marginRight)),
-        {range() { return [marginLeft, width - marginRight]; }});
+      {
+        range() {
+          return [marginLeft, width - marginRight];
+        },
+      }
+    );
 
-    svg.append("image")
-        .attr("x", marginLeft)
-        .attr("y", marginTop)
-        .attr("width", width - marginLeft - marginRight)
-        .attr("height", height - marginTop - marginBottom)
-        .attr("preserveAspectRatio", "none")
-        .attr("xlink:href", ramp(color.interpolator()).toDataURL());
+    svg
+      .append('image')
+      .attr('x', marginLeft)
+      .attr('y', marginTop)
+      .attr('width', width - marginLeft - marginRight)
+      .attr('height', height - marginTop - marginBottom)
+      .attr('preserveAspectRatio', 'none')
+      .attr('xlink:href', ramp(color.interpolator()).toDataURL());
 
     // scaleSequentialQuantile doesn’t implement ticks or tickFormat.
     if (!x.ticks) {
       if (tickValues === undefined) {
         const n = Math.round(ticks + 1);
-        tickValues = d3.range(n).map(i => d3.quantile(color.domain(), i / (n - 1)));
+        tickValues = d3
+          .range(n)
+          .map((i) => d3.quantile(color.domain(), i / (n - 1)));
       }
-      if (typeof tickFormat !== "function") {
-        tickFormat = d3.format(tickFormat === undefined ? ",f" : tickFormat);
+      if (typeof tickFormat !== 'function') {
+        tickFormat = d3.format(tickFormat === undefined ? ',f' : tickFormat);
       }
     }
   }
 
   // Threshold
   else if (color.invertExtent) {
-    const thresholds
-        = color.thresholds ? color.thresholds() // scaleQuantize
-        : color.quantiles ? color.quantiles() // scaleQuantile
-        : color.domain(); // scaleThreshold
+    const thresholds = color.thresholds
+      ? color.thresholds() // scaleQuantize
+      : color.quantiles
+      ? color.quantiles() // scaleQuantile
+      : color.domain(); // scaleThreshold
 
-    const thresholdFormat
-        = tickFormat === undefined ? d => d
-        : typeof tickFormat === "string" ? d3.format(tickFormat)
+    const thresholdFormat =
+      tickFormat === undefined
+        ? (d) => d
+        : typeof tickFormat === 'string'
+        ? d3.format(tickFormat)
         : tickFormat;
 
-    x = d3.scaleLinear()
-        .domain([-1, color.range().length - 1])
-        .rangeRound([marginLeft, width - marginRight]);
+    x = d3
+      .scaleLinear()
+      .domain([-1, color.range().length - 1])
+      .rangeRound([marginLeft, width - marginRight]);
 
-    svg.append("g")
-      .selectAll("rect")
+    svg
+      .append('g')
+      .selectAll('rect')
       .data(color.range())
-      .join("rect")
-        .attr("x", (d, i) => x(i - 1))
-        .attr("y", marginTop)
-        .attr("width", (d, i) => x(i) - x(i - 1))
-        .attr("height", height - marginTop - marginBottom)
-        .attr("fill", d => d);
+      .join('rect')
+      .attr('x', (d, i) => x(i - 1))
+      .attr('y', marginTop)
+      .attr('width', (d, i) => x(i) - x(i - 1))
+      .attr('height', height - marginTop - marginBottom)
+      .attr('fill', (d) => d);
 
     tickValues = d3.range(thresholds.length);
-    tickFormat = i => thresholdFormat(thresholds[i], i);
+    tickFormat = (i) => thresholdFormat(thresholds[i], i);
   }
 
   // Ordinal
   else {
-    x = d3.scaleBand()
-        .domain(color.domain())
-        .rangeRound([marginLeft, width - marginRight]);
+    x = d3
+      .scaleBand()
+      .domain(color.domain())
+      .rangeRound([marginLeft, width - marginRight]);
 
-    svg.append("g")
-      .selectAll("rect")
+    svg
+      .append('g')
+      .selectAll('rect')
       .data(color.domain())
-      .join("rect")
-        .attr("x", x)
-        .attr("y", marginTop)
-        .attr("width", Math.max(0, x.bandwidth() - 1))
-        .attr("height", height - marginTop - marginBottom)
-        .attr("fill", color);
+      .join('rect')
+      .attr('x', x)
+      .attr('y', marginTop)
+      .attr('width', Math.max(0, x.bandwidth() - 1))
+      .attr('height', height - marginTop - marginBottom)
+      .attr('fill', color);
 
     tickAdjust = () => {};
   }
 
-  svg.append("g")
-      .attr("transform", `translate(0,${height - marginBottom})`)
-      .call(d3.axisBottom(x)
-        .ticks(ticks, typeof tickFormat === "string" ? tickFormat : undefined)
-        .tickFormat(typeof tickFormat === "function" ? tickFormat : undefined)
+  svg
+    .append('g')
+    .attr('transform', `translate(0,${height - marginBottom})`)
+    .call(
+      d3
+        .axisBottom(x)
+        .ticks(ticks, typeof tickFormat === 'string' ? tickFormat : undefined)
+        .tickFormat(typeof tickFormat === 'function' ? tickFormat : undefined)
         .tickSize(tickSize)
-        .tickValues(tickValues))
-      .call(tickAdjust)
-      .call(g => g.select(".domain").remove())
-      .call(g => g.append("text")
-        .attr("x", marginLeft)
-        .attr("y", marginTop + marginBottom - height - 6)
-        .attr("fill", "currentColor")
-        .attr("text-anchor", "start")
-        .attr("font-weight", "bold")
-        .text(title));
+        .tickValues(tickValues)
+    )
+    .call(tickAdjust)
+    .call((g) => g.select('.domain').remove())
+    .call((g) =>
+      g
+        .append('text')
+        .attr('x', marginLeft)
+        .attr('y', marginTop + marginBottom - height - 6)
+        .attr('fill', 'currentColor')
+        .attr('text-anchor', 'start')
+        .attr('font-weight', 'bold')
+        .text(title)
+    );
 
   return svg.node();
-};
+}
 
 function ramp(color, n = 256) {
-  const canvas = document.createElement("canvas");
-  const context = (canvas.width = n, canvas.height = 1, canvas).getContext("2d");
+  const canvas = document.createElement('canvas');
+  const context = ((canvas.width = n), (canvas.height = 1), canvas).getContext(
+    '2d'
+  );
   for (let i = 0; i < n; ++i) {
     context.fillStyle = color(i / (n - 1));
     context.fillRect(i, 0, 1, 1);

--- a/src/components/legend.js
+++ b/src/components/legend.js
@@ -23,8 +23,11 @@ function legend({
     .style('overflow', 'visible')
     .style('display', 'block');
 
-  let tickAdjust = (g) =>
-    g.selectAll('.tick line').attr('y1', marginTop + marginBottom - height);
+  let tickAdjust = (g) => {
+    const ticks = g.selectAll('.tick line');
+    ticks.attr('y1', marginTop + marginBottom - height);
+    d3.select(ticks.nodes()[ticks.size() - 1]).remove();
+  };
   let x;
 
   // Continuous
@@ -119,8 +122,14 @@ function legend({
       .attr('height', height - marginTop - marginBottom)
       .attr('fill', (d) => d);
 
-    tickValues = d3.range(thresholds.length);
-    tickFormat = (i) => thresholdFormat(thresholds[i], i);
+    tickValues = d3.range(-1, thresholds.length);
+    tickFormat = (i) => {
+      if (i === -1) return thresholdFormat(1);
+      else if (i === thresholds.length - 1) return;
+      else if (i === thresholds.length - 2)
+        return thresholdFormat(thresholds[i] + '+', i);
+      return thresholdFormat(thresholds[i], i);
+    };
   }
 
   // Ordinal


### PR DESCRIPTION
**Description of PR**
This PR will
- Increase map sizes by making them span entire width of the section 
- Cache maps which have previously been loaded. Toggle the display style of extra maps to 'none' when they're out of view, instead of removing them from SVG
- Add zoom animation to transitions between country and state maps
- Move legend below map. Use d3-scale instead of manual interpolation
- Move the district information text above the map
- Sneak in uniform scaling disabled by default

**PS :** I'm aware that animations stutter on Chromium-based browsers on Android. This seems to me like a bug in how SVGs are rendered in Chromium. The behaviour's better in Chrome Canary. Since I don't have the slightest idea as to how debugging is done in Chrome/Android, any help is much appreciated.

**Type of PR**

- [x] Bugfix
- [x] New feature

**Relevant Issues**  
Fixes #57 (finally) , fixes #504, fixes #785 (somewhat), fixes #1045 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Peek 2020-04-10 13-13](https://user-images.githubusercontent.com/27727946/78973239-1be5a100-7b2d-11ea-8f04-33d94cae5296.gif)
