### PR TITLE
Corrected some district names in Maharashtra state

### DIFF
--- a/public/maps/maharashtra.json
+++ b/public/maps/maharashtra.json
@@ -5258,7 +5258,7 @@
           "type": "Polygon",
           "properties": {
             "dt_code": "507",
-            "district": "Gondiya",
+            "district": "Gondia",
             "st_nm": "Maharashtra",
             "st_code": "27",
             "year": "2011_c"
@@ -5390,7 +5390,7 @@
           "type": "Polygon",
           "properties": {
             "dt_code": "522",
-            "district": "Ahmadnagar",
+            "district": "Ahmednagar",
             "st_nm": "Maharashtra",
             "st_code": "27",
             "year": "2011_c"
@@ -5445,7 +5445,7 @@
           "type": "Polygon",
           "properties": {
             "dt_code": "523",
-            "district": "Bid",
+            "district": "Beed",
             "st_nm": "Maharashtra",
             "st_code": "27",
             "year": "2011_c"


### PR DESCRIPTION
**Description of PR**
There was typo in three of the districts of Maharsahtra.
"Bid"-->"Beed"
https://en.wikipedia.org/wiki/Beed
"Gondiya"-->"Gondia"
https://en.wikipedia.org/wiki/Gondia
"Ahmadnagar"-->"Ahmednagar"
https://en.wikipedia.org/wiki/Ahmednagar

**Type of PR**
- [ ✓] Bugfix

**Relevant Issues**  
Fixes #...

**Checklist**

- [ ✓] Compiles and passes lint tests
- [✓ ] Properly formatted
- [✓ ] Tested on desktop
- [✓ ] Tested on phone

**Screenshots**
