### PR TITLE
Associate scale mode labels with with corresponding switch (#895)

### DIFF
--- a/src/components/home.js
+++ b/src/components/home.js
@@ -148,6 +148,7 @@ function Home(props) {
                   <div className="timeseries-mode">
                     <label htmlFor="timeseries-mode">Uniform</label>
                     <input
+                      id="timeseries-mode"
                       type="checkbox"
                       checked={timeseriesMode}
                       className="switch"
@@ -164,6 +165,7 @@ function Home(props) {
                   >
                     <label htmlFor="timeseries-logmode">Logarithmic</label>
                     <input
+                      id="timeseries-logmode"
                       type="checkbox"
                       checked={graphOption === 1 && timeseriesLogMode}
                       className="switch"


### PR DESCRIPTION
**Description of PR**
This PR allows labels to be clicked/tapped for scale mode toggle switches, increasing the click/tap area.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #895...

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
