### PR TITLE
Added flex wrap to container of map-stats tiles

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2785,7 +2785,7 @@ select {
   .MapExplorer {
     .map-stats {
       flex-wrap: wrap;
-      height: auto;
+      height: 12rem;
       width: calc(100% + 0.5rem);
       margin: -0.25rem;
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -2781,6 +2781,16 @@ select {
   .PatientsDB .modal .modal-content .meta {
     height: 25rem !important;
   }
+
+  .MapExplorer {
+    .map-stats{
+      flex-wrap: wrap;
+      height: 10rem;
+      .stats{
+        margin-left: 0;
+      }
+    }
+  }
 }
 
 .cards-container {

--- a/src/App.scss
+++ b/src/App.scss
@@ -1241,8 +1241,9 @@ table {
   .map-stats {
     display: flex;
     flex-direction: row;
-    width: 100%;
-    height: 5rem;
+    flex-wrap: wrap;
+    width: calc(100% + 0.5rem);
+    margin-left: -0.25rem;
     position: relative;
 
     h1,
@@ -1343,14 +1344,6 @@ table {
             stroke: $purple;
           }
         }
-      }
-
-      &:first-child {
-        margin-left: 0;
-      }
-
-      &:last-child {
-        margin-right: 0;
       }
     }
   }

--- a/src/App.scss
+++ b/src/App.scss
@@ -2785,7 +2785,8 @@ select {
   .MapExplorer {
     .map-stats{
       flex-wrap: wrap;
-      height: 10rem;
+      height: auto;
+      vertical-align: center;
       .stats{
         margin-left: 0;
       }

--- a/src/App.scss
+++ b/src/App.scss
@@ -2786,7 +2786,6 @@ select {
     .map-stats{
       flex-wrap: wrap;
       height: auto;
-      vertical-align: center;
       .stats{
         margin-left: 0;
       }

--- a/src/App.scss
+++ b/src/App.scss
@@ -1241,9 +1241,8 @@ table {
   .map-stats {
     display: flex;
     flex-direction: row;
-    flex-wrap: wrap;
-    width: calc(100% + 0.5rem);
-    margin-left: -0.25rem;
+    width: 100%;
+    height: 5rem;
     position: relative;
 
     h1,
@@ -1344,6 +1343,14 @@ table {
             stroke: $purple;
           }
         }
+      }
+
+      &:first-child {
+        margin-left: 0;
+      }
+
+      &:last-child {
+        margin-right: 0;
       }
     }
   }
@@ -2776,11 +2783,22 @@ select {
   }
 
   .MapExplorer {
-    .map-stats{
+    .map-stats {
       flex-wrap: wrap;
       height: auto;
-      .stats{
-        margin-left: 0;
+      width: calc(100% + 0.5rem);
+      margin: -0.25rem;
+
+      .stats {
+        flex: 1 30%;
+
+        &:first-child {
+          margin-left: 0.25rem;
+        }
+  
+        &:last-child {
+          margin-right: 0.25rem;
+        }
       }
     }
   }


### PR DESCRIPTION
**Description of PR**
Map tiles were breaking in mobile devices, as it was getting out of the container. and the complete container was showing white space on right in mobile devices.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues** 
Fixes #951 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
Mobile:
<img width="358" alt="Screenshot 2020-04-11 at 7 16 51 PM" src="https://user-images.githubusercontent.com/20279468/79045530-4026a800-7c29-11ea-9f7f-2bda8ada5d59.png">

Desktop:
<img width="1308" alt="Screenshot 2020-04-11 at 7 18 13 PM" src="https://user-images.githubusercontent.com/20279468/79045538-47e64c80-7c29-11ea-8a80-f685ce316f40.png">
