### PR TITLE
Fix: Show the confirmed cases in DeepDive dailys.

### DIFF
--- a/src/components/Charts/dailyconfirmedchart.js
+++ b/src/components/Charts/dailyconfirmedchart.js
@@ -23,9 +23,7 @@ function DailyConfirmedChart(props) {
   props.timeseries.forEach((data, index) => {
     if (index >= 31) {
       dates.push(moment(data.date.trim(), 'DD MMM').format('DD MMM'));
-      confirmed.push(
-        data.dailyconfirmed - data.dailyrecovered - data.dailydeceased
-      );
+      confirmed.push(data.dailyconfirmed);
       recovered.push(data.dailyrecovered);
       deceased.push(data.dailydeceased);
     }
@@ -46,7 +44,7 @@ function DailyConfirmedChart(props) {
       },
       {
         data: confirmed,
-        label: 'Active',
+        label: 'confirmed',
         backgroundColor: '#ff6862',
       },
     ],


### PR DESCRIPTION
**Description of PR**
Deep-dive bug of showing active cases inspite of new cases.

**Type of PR**
- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #1056 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Screenshot from 2020-04-14 02-39-35](https://user-images.githubusercontent.com/45959932/79161555-4d928c80-7df9-11ea-834b-3879f4c386f4.png)
