### PR TITLE
Improv: Limit dailys cases by weeks and beginning in DeepDive.

### DIFF
--- a/src/components/Charts/dailyconfirmedchart.js
+++ b/src/components/Charts/dailyconfirmedchart.js
@@ -11,24 +11,28 @@ import React from 'react';
 import {Bar, defaults} from 'react-chartjs-2';
 
 function DailyConfirmedChart(props) {
-  const dates = [];
-  const confirmed = [];
-  const recovered = [];
-  const deceased = [];
+  const [range, setRange] = React.useState(31);
+  let dates = [];
+  let confirmed = [];
+  let recovered = [];
+  let deceased = [];
 
   if (!props.timeseries || props.timeseries.length === 0) {
     return <div></div>;
   }
 
-  props.timeseries.forEach((data, index) => {
-    if (index >= 31) {
-      const date = parse(data.date, 'dd MMMM', new Date(2020, 0, 1));
-      dates.push(format(date, 'dd MMM'));
-      confirmed.push(data.dailyconfirmed);
-      recovered.push(data.dailyrecovered);
-      deceased.push(data.dailydeceased);
-    }
-  });
+  for (
+    let i = range !== 31 ? props.timeseries.length - range : range;
+    i < props.timeseries.length;
+    i++
+  ) {
+    const data = props.timeseries[i];
+    const date = parse(data.date, 'dd MMMM', new Date(2020, 0, 1));
+    dates.push(format(date, 'dd MMM'));
+    confirmed.push(data.dailyconfirmed);
+    recovered.push(data.dailyrecovered);
+    deceased.push(data.dailydeceased);
+  }
 
   const barDataSet = {
     labels: dates,
@@ -92,6 +96,26 @@ function DailyConfirmedChart(props) {
       <div className="chart-content">
         <Bar data={barDataSet} options={options} />
       </div>
+      <form
+        onChange={(e) => {
+          confirmed = [];
+          recovered = [];
+          deceased = [];
+          dates = [];
+          setRange(e.target.value);
+          console.log(range);
+        }}
+        style={{display: 'inline'}}
+      >
+        <input type="radio" id="begin" name="range" value={31} defaultChecked />
+        <label htmlFor="begin">Beginning</label>
+        <input type="radio" id="6weeks" name="range" value={56} />
+        <label htmlFor="6weeks">8 weeks</label>
+        <input type="radio" id="6weeks" name="range" value={42} />
+        <label htmlFor="6weeks">6 weeks</label>
+        <input type="radio" id="4weeks" name="range" value={28} />
+        <label htmlFor="4weeks">4 weeks</label>
+      </form>
     </div>
   );
 }

--- a/src/components/Charts/dailyconfirmedchart.js
+++ b/src/components/Charts/dailyconfirmedchart.js
@@ -10,23 +10,19 @@ import deepmerge from 'deepmerge';
 import React from 'react';
 import {Bar, defaults} from 'react-chartjs-2';
 
-function DailyConfirmedChart(props) {
+function DailyConfirmedChart({title, timeseries}) {
   const [range, setRange] = React.useState(31);
   let dates = [];
   let confirmed = [];
   let recovered = [];
   let deceased = [];
 
-  if (!props.timeseries || props.timeseries.length === 0) {
+  if (!timeseries || timeseries.length === 0) {
     return <div></div>;
   }
 
-  for (
-    let i = range !== 31 ? props.timeseries.length - range : range;
-    i < props.timeseries.length;
-    i++
-  ) {
-    const data = props.timeseries[i];
+  for (let i = range; i < timeseries.length; i++) {
+    const data = timeseries[i];
     const date = parse(data.date, 'dd MMMM', new Date(2020, 0, 1));
     dates.push(format(date, 'dd MMM'));
     confirmed.push(data.dailyconfirmed);
@@ -92,7 +88,7 @@ function DailyConfirmedChart(props) {
 
   return (
     <div className="charts-header">
-      <div className="chart-title">{props.title}</div>
+      <div className="chart-title">{title}</div>
       <div className="chart-content">
         <Bar data={barDataSet} options={options} />
       </div>
@@ -109,11 +105,19 @@ function DailyConfirmedChart(props) {
       >
         <input type="radio" id="begin" name="range" value={31} defaultChecked />
         <label htmlFor="begin">Beginning</label>
-        <input type="radio" id="6weeks" name="range" value={56} />
-        <label htmlFor="6weeks">8 weeks</label>
-        <input type="radio" id="6weeks" name="range" value={42} />
+        <input
+          type="radio"
+          id="6weeks"
+          name="range"
+          value={timeseries.length - 42}
+        />
         <label htmlFor="6weeks">6 weeks</label>
-        <input type="radio" id="4weeks" name="range" value={28} />
+        <input
+          type="radio"
+          id="4weeks"
+          name="range"
+          value={timeseries.length - 28}
+        />
         <label htmlFor="4weeks">4 weeks</label>
       </form>
     </div>

--- a/src/components/Charts/dailyconfirmedchart.js
+++ b/src/components/Charts/dailyconfirmedchart.js
@@ -99,7 +99,6 @@ function DailyConfirmedChart({title, timeseries}) {
           deceased = [];
           dates = [];
           setRange(e.target.value);
-          console.log(range);
         }}
         style={{display: 'inline'}}
       >


### PR DESCRIPTION
**Description of PR**
* this PR will show bar plot of daily cases according to user choice. this will improve look of plot and user will be able to see the cases easily even in mobile Devices.

> currently bar plot is showing daily cases from 1 march to today date. which is making plot very clumsy and thin and this plot is going to be thin dailywise. i have raised this PR  to solve this issue by giving users to see Daily cases graph as they wish.

**Type of PR**
- [x] new Feature

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
#### current situation of Daily cases
![Screenshot from 2020-04-30 01-30-23](https://user-images.githubusercontent.com/45959932/80641362-639f7e80-8a82-11ea-88a1-a14819ff29f1.png)
<br>
#### After 
![graph](https://user-images.githubusercontent.com/45959932/80641376-68fcc900-8a82-11ea-836d-cdfe9384662b.gif)
