### PR TITLE
fix[navbar]: close navbar on click outside on mobile

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -1,8 +1,24 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 import {Link} from 'react-router-dom';
 
 function Navbar(props) {
   const [menuVisible, setMenuVisible] = useState(false);
+  const navRef = useRef(null);
+
+  const handleClickOutside = (e) => {
+    if (navRef && navRef.current && !navRef.current.contains(e.target)) {
+      setMenuVisible(false);
+    }
+  };
+
+  useEffect(() => {
+    if (menuVisible && window.innerWidth <= 768) {
+      window.addEventListener('click', handleClickOutside);
+    }
+    return () => {
+      window.removeEventListener('click', handleClickOutside);
+    };
+  }, [menuVisible]);
 
   // HTML Properties for each of the links in UI
   const navLinkProps = (path, animationDelay) => ({
@@ -20,6 +36,7 @@ function Navbar(props) {
           animationDelay: '0.5s',
           transition: 'all 0.3s ease-in-out',
         }}
+        ref={navRef}
       >
         <Link to="/">
           <img


### PR DESCRIPTION
**Description of PR**
Closes navbar when the user clicks outside it on mobile devices

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #878 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone


