### PR TITLE
Fix crash because of timeseries index overflow

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -12,7 +12,7 @@ function TimeSeries(props) {
   );
   const [timeseries, setTimeseries] = useState([]);
   const [datapoint, setDatapoint] = useState({});
-  const [index, setIndex] = useState(10);
+  const [index, setIndex] = useState(0);
   const [mode, setMode] = useState(props.mode);
   const [logMode, setLogMode] = useState(props.logMode);
   const [chartType, setChartType] = useState(props.type);
@@ -369,7 +369,8 @@ function TimeSeries(props) {
 
   // Function for calculate increased/decreased count for each type of data
   const currentStatusCount = (chartType) => {
-    if (timeseries.length <= 0 || index === 0) return '';
+    if (timeseries.length <= 0 || index <= 0 || index >= timeseries.length)
+      return '';
     const currentDiff =
       timeseries[index][chartType] - timeseries[index - 1][chartType];
     const formatedDiff = formatNumber(currentDiff);


### PR DESCRIPTION
**Description of PR**
Fixes intermittent crashing of website because of array index overflow.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone