### PR TITLE
Fix Call Multiple Times of log.json file

### DIFF
--- a/src/components/updates.js
+++ b/src/components/updates.js
@@ -4,17 +4,25 @@ import axios from 'axios';
 
 function Updates(props) {
   const [updates, setUpdates] = useState([]);
+  const [fetched, setFetched] = useState(false);
 
   useEffect(() => {
-    axios
-      .get('https://api.covid19india.org/updatelog/log.json')
-      .then((response) => {
-        setUpdates(response.data);
-      })
-      .catch((err) => {
-        console.log(err);
-      });
-  });
+    if (fetched === false) {
+      getStates();
+    }
+  }, [fetched]);
+
+  const getStates = async () => {
+    try {
+      const [response] = await Promise.all([
+        axios.get('https://api.covid19india.org/updatelog/log.json'),
+      ]);
+      setUpdates(response.data);
+      setFetched(true);
+    } catch (err) {
+      console.log(err);
+    }
+  };
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Fix an infinite number of requests for log.json file on clicking notification icon.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #1145 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [ ] Tested on phone

**Screenshots**
![image](https://user-images.githubusercontent.com/11550572/79432212-24385300-7fe9-11ea-9034-9661f72b8da5.png)

