### PR TITLE
Fix: Icon padding in the footer links.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1232,6 +1232,7 @@ h6 {
   svg {
     width: 20px;
     stroke-width: 2px;
+    padding-right: 6px;
   }
 
   &.is-purple {


### PR DESCRIPTION
Hi guys,

Great work on this beautiful portal. However, I found a minor issue in the bottom links where SVG and text are very nearby to each other which doesn't look professional. 

![Screenshot from 2020-04-16 14-46-57](https://user-images.githubusercontent.com/3647841/79438544-47670080-7ff1-11ea-837e-5ad1d16f3e13.png)

So, I've fixed that. Now, it looks like this.

![Screenshot from 2020-04-16 14-49-12](https://user-images.githubusercontent.com/3647841/79438722-8b5a0580-7ff1-11ea-9003-5f5584c81162.png)

Let me know if this makes sense.

Thanks!