### PR TITLE
Fix for Unknown districts count style

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1752,7 +1752,9 @@ table {
 
     .unknown {
       position: absolute;
-      top: 6rem;
+      top: 3rem;
+      right: 0;
+      text-align: right;
       width: 5rem;
       font-weight: 600;
       font-weight: 0.75rem;


### PR DESCRIPTION
**Description of PR**
Fix for Unknown districts count style, text is overlapping with map, so moved it to right top corner instead

**Type of PR**
- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #1144 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![image](https://user-images.githubusercontent.com/15967809/79445274-09220f00-7ffa-11ea-9acf-8f64a943155b.png)
