### PR TITLE
Fix for test cases failing because of 00584fa 

### DIFF
--- a/src/__tests__/components/Level.test.js
+++ b/src/__tests__/components/Level.test.js
@@ -2,30 +2,18 @@ import React from 'react';
 import {render} from '@testing-library/react';
 import Level from '../../components/level';
 
-const states = [
-  {
-    deltaconfirmed: '10',
-    deltadeaths: '3',
-    deltarecovered: '5',
-  },
-  {
-    active: '75',
-    confirmed: '83',
-    deaths: '3',
-    recovered: '5',
-    state: 'Karnataka',
-  },
-  {
-    active: '5',
-    confirmed: '3',
-    deaths: '1',
-    recovered: '2',
-    state: 'Gujarat',
-  },
-];
+const data = {
+  active: '80',
+  confirmed: '86',
+  recovered: '7',
+  deaths: '4',
+  deltaconfirmed: '10',
+  deltadeaths: '3',
+  deltarecovered: '5',
+};
 
 test('Level renders total state data', () => {
-  const {container} = render(<Level data={states} />);
+  const {container} = render(<Level data={data} />);
 
   expect(container).toHaveTextContent(
     'Confirmed[+10]86 Active 80Recovered[+5]7 Deceased[+3]4'

--- a/src/__tests__/components/Level.test.js
+++ b/src/__tests__/components/Level.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {render} from '@testing-library/react';
 import Level from '../../components/level';
 
-const data = {
+const state = {
   active: '80',
   confirmed: '86',
   recovered: '7',
@@ -13,7 +13,7 @@ const data = {
 };
 
 test('Level renders total state data', () => {
-  const {container} = render(<Level data={data} />);
+  const {container} = render(<Level data={state} />);
 
   expect(container).toHaveTextContent(
     'Confirmed[+10]86 Active 80Recovered[+5]7 Deceased[+3]4'


### PR DESCRIPTION
**Description of PR**
 Because of this commit: [00584fa](https://github.com/covid19india/covid19india-react/commit/00584fa82e87472952e0a3118af9811281d1e1ae), test cases/specs are failing for all PRs in Github actions as props data object is changed now

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
None

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
Previous:
![image](https://user-images.githubusercontent.com/15967809/79451097-9c137700-8003-11ea-98ad-ade6309e06fb.png)

Current:
![image](https://user-images.githubusercontent.com/15967809/79451273-ebf23e00-8003-11ea-9b0a-0d1a6af2b9c4.png)
