### PR TITLE
Homepage Searchbar : have the placeholder inside the search bar

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -928,7 +928,7 @@ h6 {
     svg {
       position: absolute;
       left: 0.75rem;
-      top: 4.15rem;
+      top: 1.313rem;
       color: $gray-mid;
       transition: all 0.2s ease-in-out;
     }

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -117,12 +117,11 @@ function Search(props) {
 
   return (
     <div className="Search">
-      <label>Search your city, resources, etc</label>
-      <div className="line"></div>
       <input
         type="text"
         value={searchValue}
         ref={searchInput}
+        placeholder={'Search your city, resources, etc.'}
         onFocus={(event) => {
           setExpand(true);
         }}


### PR DESCRIPTION
**Description of PR**
This updates the placeholder text for the search bar 
**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes #1194 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Desktop 

Before
![image](https://user-images.githubusercontent.com/11074737/79495355-1b27a000-8042-11ea-87db-34436a2c0f49.png)
After
![image](https://user-images.githubusercontent.com/11074737/79495958-0ef01280-8043-11ea-96fa-bfb3912b3a73.png)

Mobile 

Before 
![image](https://user-images.githubusercontent.com/11074737/79496037-3515b280-8043-11ea-8169-d16757768ad1.png)

After
![image](https://user-images.githubusercontent.com/11074737/79496108-4a8adc80-8043-11ea-9988-e7301f3d11c2.png)
