### PR TITLE
Fix uniform scaling in daily trends

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -171,7 +171,13 @@ function TimeSeries(props) {
           .clamp(true)
           .domain([
             0,
-            Math.max(1, yBuffer * d3.max(ts, (d) => d.dailyconfirmed)),
+            Math.max(
+              1,
+              yBuffer *
+                d3.max(ts, (d) =>
+                  Math.max(d.dailyconfirmed, d.dailyrecovered, d.dailydeceased)
+                )
+            ),
           ])
           .nice()
           .range([chartBottom, margin.top]);


### PR DESCRIPTION
**Description of PR**
Take maximum of delta confirmed, recovered and deceased for determining the uniform scale. Fixes issues in daily charts of some states like Andaman and Nicobar Islands.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
The tallest bar in recovered has value 10, but it appears to be only 5-6.
![image](https://user-images.githubusercontent.com/27727946/79552489-b9564d00-80b8-11ea-9728-7fa932af870a.png)

After:
![image](https://user-images.githubusercontent.com/27727946/79552515-c115f180-80b8-11ea-9cbd-0f0b9b5e9f9e.png)
