### PR TITLE
Fix: districts dropdown list on clicking the state name row in table

### DIFF
--- a/src/components/row.js
+++ b/src/components/row.js
@@ -96,15 +96,17 @@ function Row(props) {
         style={{background: props.index % 2 === 0 ? '#f8f9fa' : ''}}
       >
         <td style={{fontWeight: 600}}>
-          <div className="table__title-wrapper">
+          <div
+            className="table__title-wrapper"
+            onClick={() => {
+              handleReveal();
+            }}
+          >
             <span
               className={`dropdown ${
                 props.reveal ? 'rotateRightDown' : 'rotateDownRight'
               }`}
               style={{display: !props.total ? '' : 'none'}}
-              onClick={() => {
-                handleReveal();
-              }}
             >
               <Icon.ChevronDown />
             </span>


### PR DESCRIPTION
**Description of PR**
Clikcing/tapping on the state name in table will show the districts dropdown list as it used to. Currently, only clicking/tapping on the `ChevronDown` arrow icon expands/shows the districts info list.
Just moved the onclick handler on `span` with icon to the parent `div`.

**Type of PR**
- [x] Bugfix

**Relevant Issues**  
Fixes #1180, #1181 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [ ] Tested on phone
