### PR TITLE
fixed height for stats div

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1793,6 +1793,7 @@ table {
       margin-bottom: 0.5rem;
       flex: 1;
       padding: 0.25rem;
+      height: 46px;
 
       .stats-bottom {
         display: flex;


### PR DESCRIPTION
**Description of PR**
Made the height of stats div fixed for all states regardless of numbers.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #1200

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
Before fix
![Screenshot from 2020-04-17 02-37-47](https://user-images.githubusercontent.com/11428805/79557286-ec500f00-80bf-11ea-95c1-634393bb5245.png)

After fix
![Screenshot from 2020-04-17 15-26-51](https://user-images.githubusercontent.com/11428805/79557303-f3771d00-80bf-11ea-9db6-81f27fd1b477.png)

