### PR TITLE
Fix: Stop propagation of click on tooltip when active

### DIFF
--- a/src/components/row.js
+++ b/src/components/row.js
@@ -34,6 +34,10 @@ function Row(props) {
     props.handleReveal(props.state.state);
   };
 
+  const handleTooltip = (e) => {
+    e.stopPropagation();
+  };
+
   const sortDistricts = useCallback(
     (aDistricts) => {
       const sorted = {};
@@ -111,26 +115,31 @@ function Row(props) {
             <span className="actual__title-wrapper">
               {state.state}
               {state.statenotes && (
-                <Tooltip
-                  content={[`${state.statenotes}`]}
-                  styles={{
-                    tooltip: {
-                      background: '#000',
-                      borderRadius: '10px',
-                      fontSize: '.8em',
-                      left: '250%',
-                      opacity: 0.65,
-                    },
-                    wrapper: {
-                      cursor: 'cursor',
-                      display: 'inline-block',
-                      position: 'relative',
-                      textAlign: 'center',
-                    },
-                  }}
-                >
-                  <Icon.Info />
-                </Tooltip>
+                <span onClick={handleTooltip}>
+                  <Tooltip
+                    content={[`${state.statenotes}`]}
+                    styles={{
+                      tooltip: {
+                        background: '#000',
+                        borderRadius: '10px',
+                        fontSize: '.8em',
+                        left: '250%',
+                        opacity: 0.65,
+                      },
+                      wrapper: {
+                        cursor: 'cursor',
+                        display: 'inline-block',
+                        position: 'relative',
+                        textAlign: 'center',
+                      },
+                      arrow: {
+                        left: '37%',
+                      },
+                    }}
+                  >
+                    <Icon.Info />
+                  </Tooltip>
+                </span>
               )}
             </span>
           </div>


### PR DESCRIPTION
**Description of PR**
When tooltip icon is tapped for a state if available, the districts of the states doesn't show up.


**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #1214 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
