### PR TITLE
Beed, MH is misspelled!

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -2153,7 +2153,7 @@ export const DISTRICTS_ARRAY = [
     state: 'Maharashtra',
   },
   {
-    district: 'Bid',
+    district: 'Beed',
     othernamesspellings: '',
     state: 'Maharashtra',
   },


### PR DESCRIPTION


**Description of PR**
Beed, MH is misspelled!
Source - https://en.wikipedia.org/wiki/Beed_district
**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #...

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
