### PR TITLE
Add Null check to handle app crashes

### DIFF
--- a/src/components/state.js
+++ b/src/components/state.js
@@ -159,18 +159,20 @@ function State(props) {
                 <Icon.Compass />
                 <div className="sources-right">
                   Data collected from sources{' '}
-                  {Object.keys(sources[0]).map((key) => {
-                    if (key.match('source') && sources[0][key] !== '') {
-                      const num = key.match(/\d+/);
-                      return (
-                        <React.Fragment>
-                          {num > 1 ? ',' : ''}
-                          <a href={sources[0][key]}>{num}</a>
-                        </React.Fragment>
-                      );
-                    }
-                    return null;
-                  })}
+                  {sources.length > 0
+                    ? Object.keys(sources[0]).map((key) => {
+                        if (key.match('source') && sources[0][key] !== '') {
+                          const num = key.match(/\d+/);
+                          return (
+                            <React.Fragment>
+                              {num > 1 ? ',' : ''}
+                              <a href={sources[0][key]}>{num}</a>
+                            </React.Fragment>
+                          );
+                        }
+                        return null;
+                      })
+                    : ''}
                 </div>
               </div>
             </div>
@@ -187,35 +189,40 @@ function State(props) {
                 >
                   <h2>Top districts</h2>
                   <div className="districts">
-                    {Object.keys(districtData[stateName].districtData)
-                      .slice(0, 6)
-                      .sort(
-                        (a, b) =>
-                          districtData[stateName].districtData[b].confirmed -
-                          districtData[stateName].districtData[a].confirmed
-                      )
-                      .map((district, index) => {
-                        return (
-                          <div key={index} className="district">
-                            <h2>
-                              {
-                                districtData[stateName].districtData[district]
-                                  .confirmed
-                              }
-                            </h2>
-                            <h5>{district}</h5>
-                            <div className="delta">
-                              <Icon.ArrowUp />
-                              <h6>
-                                {
-                                  districtData[stateName].districtData[district]
-                                    .delta.confirmed
-                                }
-                              </h6>
-                            </div>
-                          </div>
-                        );
-                      })}
+                    {districtData[stateName]
+                      ? Object.keys(districtData[stateName].districtData)
+                          .slice(0, 6)
+                          .sort(
+                            (a, b) =>
+                              districtData[stateName].districtData[b]
+                                .confirmed -
+                              districtData[stateName].districtData[a].confirmed
+                          )
+                          .map((district, index) => {
+                            return (
+                              <div key={index} className="district">
+                                <h2>
+                                  {
+                                    districtData[stateName].districtData[
+                                      district
+                                    ].confirmed
+                                  }
+                                </h2>
+                                <h5>{district}</h5>
+                                <div className="delta">
+                                  <Icon.ArrowUp />
+                                  <h6>
+                                    {
+                                      districtData[stateName].districtData[
+                                        district
+                                      ].delta.confirmed
+                                    }
+                                  </h6>
+                                </div>
+                              </div>
+                            );
+                          })
+                      : ''}
                   </div>
                 </div>
                 <div className="district-bar-right">


### PR DESCRIPTION
**Description of PR** - App **Crashes** on the state Information page like this URL `https://www.covid19india.org/state/SK`. This is because of unhandled null checks so I have added those checks with prettier. Attached are the before and after Screenshots.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #...

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
**Before**
<img width="1439" alt="Screenshot 2020-04-17 at 11 48 57 PM" src="https://user-images.githubusercontent.com/22426418/79601256-2ba14e80-8106-11ea-9380-995e39aa66e8.png">

**After**
<img width="1439" alt="Screenshot 2020-04-17 at 11 49 37 PM" src="https://user-images.githubusercontent.com/22426418/79601291-34922000-8106-11ea-905f-dcca521a5547.png">

