### PR TITLE
Refactor: Replace hover events with click on map

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -445,7 +445,6 @@ h6 {
 
     .header,
     .map-stats,
-    .back-button,
     .last-update,
     .unknown,
     .state-page-button {
@@ -1814,10 +1813,6 @@ table {
   z-index: 10;
 }
 
-.back-button {
-  z-index: 11;
-}
-
 .anchor {
   cursor: pointer;
   position: absolute;
@@ -1913,19 +1908,6 @@ table {
 
     &.deceased {
       stroke: #6c757d;
-    }
-  }
-
-  .back-button {
-    background: $yellow-light;
-    color: $orange;
-    position: absolute;
-    right: 0;
-    top: 2.75rem;
-    transition: all .2s ease-in-out;
-
-    &:hover {
-      background: $yellow-hover;
     }
   }
 

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -110,8 +110,7 @@ function ChoroplethMap({
         );
       svgLegend.attr('viewBox', `0 0 ${widthLegend} ${heightLegend}`);
 
-      /* Draw map */
-      let onceTouchedRegion = null;
+      /* DRAW MAP */
       const g = svg.append('g').attr('class', mapMeta.graphObjectName);
       g.append('g')
         .attr('class', 'states')
@@ -127,17 +126,8 @@ function ChoroplethMap({
         })
         .attr('d', path)
         .attr('pointer-events', 'all')
-        .on('mouseenter', (d) => {
-          handleMouseEnter(d.properties[propertyField]);
-        })
-        .on('mouseleave', (d) => {
-          if (onceTouchedRegion === d) onceTouchedRegion = null;
-        })
-        .on('touchstart', (d) => {
-          if (onceTouchedRegion === d) onceTouchedRegion = null;
-          else onceTouchedRegion = d;
-        })
         .on('click', handleClick)
+        .on('dblclick', handleDblClick)
         .style('cursor', 'pointer')
         .append('title')
         .text(function (d) {
@@ -177,19 +167,21 @@ function ChoroplethMap({
           path(topojson.mesh(geoData, geoData.objects[mapMeta.graphObjectName]))
         );
 
-      const handleMouseEnter = (name) => {
+      function handleDblClick(d) {
+        d3.event.stopPropagation();
+        if (mapMeta.mapType === MAP_TYPES.STATE) return;
+        changeMap(d.properties[propertyField]);
+      }
+
+      function handleClick(d) {
+        d3.event.stopPropagation();
+        const name = d.properties[propertyField];
         try {
           setSelectedRegion(name);
           setHoveredRegion(name, mapMeta);
         } catch (err) {
           console.log('err', err);
         }
-      };
-
-      function handleClick(d) {
-        d3.event.stopPropagation();
-        if (onceTouchedRegion || mapMeta.mapType === MAP_TYPES.STATE) return;
-        changeMap(d.properties[propertyField]);
       }
 
       // Reset on tapping outside map

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -190,6 +190,11 @@ function ChoroplethMap({
         if (mapMeta.mapType === MAP_TYPES.COUNTRY)
           setHoveredRegion('Total', mapMeta);
       });
+      svg.on('dblclick', () => {
+        setSelectedRegion(null);
+        if (isCountryLoaded && mapMeta.mapType === MAP_TYPES.STATE)
+          changeMap('India');
+      });
     },
     [
       mapMeta,

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -356,15 +356,6 @@ function MapExplorer({
         ) : null}
 
         {currentMap.mapType === MAP_TYPES.STATE ? (
-          <div
-            className="button back-button"
-            onClick={() => switchMapToState('India')}
-          >
-            Back
-          </div>
-        ) : null}
-
-        {currentMap.mapType === MAP_TYPES.STATE ? (
           <Link to={`state/${currentHoveredRegion.statecode}`}>
             <div className="button state-page-button">
               <abbr>Visit state page</abbr>

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -213,7 +213,7 @@ function MapExplorer({
       <div className="header">
         <h1>{currentMap.name} Map</h1>
         <h6>
-          {window.innerWidth <= 769 ? 'Tap' : 'Hover'} over a{' '}
+          {window.innerWidth <= 769 ? 'Tap' : 'Click'} on a{' '}
           {currentMap.mapType === MAP_TYPES.COUNTRY ? 'state/UT' : 'district'}{' '}
           for more details
         </h6>


### PR DESCRIPTION
**Description of PR**
The behaviour is now consistent with touch screens. Single click to select, and double click to expand map.

Also removed back button. Double clicking outside map will now go back to country view.

**PS: This PR is subject to scrutiny if this behaviour does not seem fit for PC.**

**Type of PR**

- [ ] Bugfix
- [x] New feature

**Relevant Issues**  
Fixes #717, fixes #1243 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone
