### PR TITLE
Improv: Block TimeSeries scrub on scrolling

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -225,7 +225,21 @@ function TimeSeries(props) {
           .attr('r', 4);
       });
 
+      let firstTouch = false;
+      let windowScrollY = null;
+
       function mousemove() {
+        if (d3.event.type === 'touchmove') {
+          if (!firstTouch) {
+            firstTouch = true;
+            windowScrollY = window.scrollY;
+          } else if (
+            windowScrollY !== null &&
+            windowScrollY !== window.scrollY
+          ) {
+            return;
+          }
+        }
         const xm = d3.mouse(this)[0];
         const date = xScale.invert(xm);
         const bisectDate = d3.bisector((d) => d.date).left;
@@ -256,6 +270,7 @@ function TimeSeries(props) {
             yScale(timeseries[T - 1][type])
           );
         });
+        firstTouch = false;
       }
 
       /* Begin drawing charts */


### PR DESCRIPTION
**Description of PR**
On mobile devices, when you scroll up or down by using fingers on timeseries charts, tha page scrolls along with that the timeseries charts also changes (touch event gets triggered on them). This is a hack for preventing it.

**Note: This might not be a perfect solution**

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #1224

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
