### PR TITLE
Fixed: know more! link should be different in color

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -108,7 +108,10 @@ function Table(props) {
           className="table-fineprint fadeInUp"
           style={{animationDelay: '1.5s'}}
         >
-          Compiled from State Govt. numbers, <Link to="/faq">know more!</Link>
+          Compiled from State Govt. numbers,{' '}
+          <Link to="/faq" style={{color: '#6c757d'}}>
+            know more!
+          </Link>
         </h5>
         <table className="table fadeInUp" style={{animationDelay: '1.8s'}}>
           <thead>


### PR DESCRIPTION
**Description of PR**
The know more link is now visible.

**Type of PR**

- [x] Bugfix
- [x] New feature

**Relevant Issues**  
Fixes #1182 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
#### Before "know more" link
![old](https://user-images.githubusercontent.com/55312000/79669492-793abb80-81d9-11ea-91a0-e182c1cb5aea.png)

#### After "know more" link
![new](https://user-images.githubusercontent.com/55312000/79669495-7fc93300-81d9-11ea-9b33-4603f14c0c8d.png)