### PR TITLE
Consistent styling for tooltip info

### DIFF
--- a/src/components/row.js
+++ b/src/components/row.js
@@ -31,6 +31,25 @@ function Row(props) {
     setSortedDistricts(props.districts);
   }, [props.districts]);
 
+  const tooltipStyles = {
+    tooltip: {
+      background: '#000',
+      borderRadius: '10px',
+      fontSize: '.8em',
+      left: '250%',
+      opacity: 0.65,
+    },
+    wrapper: {
+      cursor: 'cursor',
+      display: 'inline-block',
+      position: 'relative',
+      textAlign: 'center',
+    },
+    arrow: {
+      left: '37%',
+    },
+  };
+
   const handleReveal = () => {
     props.handleReveal(props.state.state);
   };
@@ -119,24 +138,7 @@ function Row(props) {
                 <span onClick={handleTooltip}>
                   <Tooltip
                     content={[`${state.statenotes}`]}
-                    styles={{
-                      tooltip: {
-                        background: '#000',
-                        borderRadius: '10px',
-                        fontSize: '.8em',
-                        left: '250%',
-                        opacity: 0.65,
-                      },
-                      wrapper: {
-                        cursor: 'cursor',
-                        display: 'inline-block',
-                        position: 'relative',
-                        textAlign: 'center',
-                      },
-                      arrow: {
-                        left: '37%',
-                      },
-                    }}
+                    styles={tooltipStyles}
                   >
                     <Icon.Info />
                   </Tooltip>
@@ -326,22 +328,7 @@ function Row(props) {
               Unknown
               <Tooltip
                 content={['Awaiting patient-level details from State Bulletin']}
-                styles={{
-                  tooltip: {
-                    background: '#000',
-                    borderRadius: '5px',
-                    fontSize: '1rem',
-                    left: '250%',
-                    opacity: 1,
-                    padding: '0.5rem',
-                  },
-                  wrapper: {
-                    cursor: 'cursor',
-                    display: 'inline-block',
-                    position: 'relative',
-                    textAlign: 'center',
-                  },
-                }}
+                styles={tooltipStyles}
               >
                 <Icon.Info />
               </Tooltip>


### PR DESCRIPTION
**Description of PR**
The styling for tooltip info in district row was different from that in state row. This PR uses a common styling for both.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #1289 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
State
![Screenshot (21)](https://user-images.githubusercontent.com/11428805/79685713-6915f100-8258-11ea-9ba2-d0779f3dcac2.png)

District (Before)
![Screenshot (22)](https://user-images.githubusercontent.com/11428805/79685719-7632e000-8258-11ea-9da9-404fbb28115b.png)
District(After)
![Screenshot (24)](https://user-images.githubusercontent.com/11428805/79685721-7e8b1b00-8258-11ea-92f8-dcc5726f952f.png)

