### PR TITLE
Adding scroll to top button (w/ animation) to all pages

### DIFF
--- a/src/components/home.js
+++ b/src/components/home.js
@@ -9,7 +9,7 @@ import {
   preprocessTimeseries,
   parseStateTimeseries,
 } from '../utils/common-functions';
-import Fab from '@material-ui/core/Fab';
+import {Fab, Fade} from '@material-ui/core';
 import * as Icon from 'react-feather';
 
 import Table from './table';
@@ -45,11 +45,11 @@ function Home(props) {
   );
 
   const checkScrollEvent = useCallback((event) => {
-    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+    window.pageYOffset > 100 ? setHasScrolled(true) : setHasScrolled(false);
   }, []);
 
   useEffect(() => {
-    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+    window.pageYOffset > 100 ? setHasScrolled(true) : setHasScrolled(false);
     window.addEventListener('scroll', checkScrollEvent);
     return () => {
       window.removeEventListener('scroll', checkScrollEvent);
@@ -145,11 +145,8 @@ function Home(props) {
   // );
 
   function animateScroll() {
-    const c = document.body.scrollTop || document.documentElement.scrollTop; // For {Safari} || {Chrome, Firefox, IE and Opera}
-    if (c > 0) {
-      window.requestAnimationFrame(animateScroll);
-      window.scrollTo(0, c - c / 6); // Increase fixed constant for smoother scrolling and vice versa
-    }
+    document.body.scrollTo({top: 0, behavior: 'smooth'}); // For Safari
+    document.documentElement.scrollTo({top: 0, behavior: 'smooth'}); // For Chrome, Firefox, IE and Opera
   }
 
   return (
@@ -314,23 +311,23 @@ function Home(props) {
                 logMode={timeseriesLogMode}
               />
               <div>
-                <Fab
-                  color="inherit"
-                  aria-label="gototop"
-                  id="gototopbtn-home"
-                  onClick={animateScroll}
-                  size="small"
-                  disabled={!hasScrolled}
-                  style={{
-                    position: 'fixed',
-                    bottom: '1rem',
-                    right: '1rem',
-                    zIndex: '1000',
-                    opacity: hasScrolled ? 1 : 0,
-                  }}
-                >
-                  <Icon.Navigation2 strokeWidth="2.5" color="#4c75f2" />
-                </Fab>
+                <Fade in={hasScrolled}>
+                  <Fab
+                    color="inherit"
+                    aria-label="gototop"
+                    id="gototopbtn-home"
+                    onClick={animateScroll}
+                    size="small"
+                    style={{
+                      position: 'fixed',
+                      bottom: '1rem',
+                      right: '1rem',
+                      zIndex: '1000',
+                    }}
+                  >
+                    <Icon.Navigation2 strokeWidth="2.5" color="#4c75f2" />
+                  </Fab>
+                </Fade>
               </div>
             </React.Fragment>
           )}

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -9,6 +9,7 @@ import {
   preprocessTimeseries,
   parseStateTimeseries,
 } from '../utils/common-functions';
+import Fab from '@material-ui/core/Fab';
 import * as Icon from 'react-feather';
 
 import Table from './table';
@@ -33,6 +34,7 @@ function Home(props) {
   const [showUpdates, setShowUpdates] = useState(false);
   const [seenUpdates, setSeenUpdates] = useState(false);
   const [newUpdate, setNewUpdate] = useState(true);
+  const [hasScrolled, setHasScrolled] = useState(false);
   const [timeseriesMode, setTimeseriesMode] = useLocalStorage(
     'timeseriesMode',
     true
@@ -41,6 +43,18 @@ function Home(props) {
     'timeseriesLogMode',
     false
   );
+
+  const checkScrollEvent = useCallback((event) => {
+    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+  }, []);
+
+  useEffect(() => {
+    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+    window.addEventListener('scroll', checkScrollEvent);
+    return () => {
+      window.removeEventListener('scroll', checkScrollEvent);
+    };
+  }, [hasScrolled, checkScrollEvent]);
 
   useEffect(() => {
     // this if block is for checking if user opened a page for first time.
@@ -129,6 +143,14 @@ function Home(props) {
   //     behavior: 'smooth',
   //   })
   // );
+
+  function animateScroll() {
+    const c = document.body.scrollTop || document.documentElement.scrollTop; // For {Safari} || {Chrome, Firefox, IE and Opera}
+    if (c > 0) {
+      window.requestAnimationFrame(animateScroll);
+      window.scrollTo(0, c - c / 6); // Increase fixed constant for smoother scrolling and vice versa
+    }
+  }
 
   return (
     <React.Fragment>
@@ -291,6 +313,25 @@ function Home(props) {
                 mode={timeseriesMode}
                 logMode={timeseriesLogMode}
               />
+              <div>
+                <Fab
+                  color="inherit"
+                  aria-label="gototop"
+                  id="gototopbtn-home"
+                  onClick={animateScroll}
+                  size="small"
+                  disabled={!hasScrolled}
+                  style={{
+                    position: 'fixed',
+                    bottom: '1rem',
+                    right: '1rem',
+                    zIndex: '1000',
+                    opacity: hasScrolled ? 1 : 0,
+                  }}
+                >
+                  <Icon.Navigation2 strokeWidth="2.5" color="#4c75f2" />
+                </Fab>
+              </div>
             </React.Fragment>
           )}
         </div>

--- a/src/components/patientdb.js
+++ b/src/components/patientdb.js
@@ -1,9 +1,10 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useCallback} from 'react';
 import {useLocation} from 'react-router-dom';
 import axios from 'axios';
 import {format, subDays} from 'date-fns';
 import DatePicker from 'react-date-picker';
 import * as Icon from 'react-feather';
+import Fab from '@material-ui/core/Fab';
 
 import Patients from './patients';
 import DownloadBlock from './downloadblock';
@@ -27,6 +28,8 @@ function PatientDB(props) {
   const [colorMode, setColorMode] = useState('genders');
   const [scaleMode, setScaleMode] = useState(false);
   const [filterDate, setFilterDate] = useState(null);
+  const [hasScrolled, setHasScrolled] = useState(false);
+
   const [filters, setFilters] = useState({
     detectedstate: '',
     detecteddistrict: '',
@@ -96,6 +99,26 @@ function PatientDB(props) {
     if (setValues.size > 1) setValues.add('');
     if (key === 'dateannounced') return Array.from(setValues);
     return Array.from(setValues).sort();
+  }
+
+  const checkScrollEvent = useCallback((event) => {
+    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+  }, []);
+
+  useEffect(() => {
+    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+    window.addEventListener('scroll', checkScrollEvent);
+    return () => {
+      window.removeEventListener('scroll', checkScrollEvent);
+    };
+  }, [hasScrolled, checkScrollEvent]);
+
+  function animateScroll() {
+    const c = document.body.scrollTop || document.documentElement.scrollTop; // For {Safari} || {Chrome, Firefox, IE and Opera}
+    if (c > 0) {
+      window.requestAnimationFrame(animateScroll);
+      window.scrollTo(0, c - c / 6); // Increase fixed constant for smoother scrolling and vice versa
+    }
   }
 
   return (
@@ -352,6 +375,26 @@ function PatientDB(props) {
         />
       </div>
       <DownloadBlock patients={patients} />
+
+      <div>
+        <Fab
+          color="inherit"
+          aria-label="gototop"
+          id="gototopbtn-patients"
+          onClick={animateScroll}
+          size="small"
+          disabled={!hasScrolled}
+          style={{
+            position: 'fixed',
+            bottom: '1rem',
+            right: '1rem',
+            zIndex: '1000',
+            opacity: hasScrolled ? 1 : 0,
+          }}
+        >
+          <Icon.Navigation2 strokeWidth="2.5" color="#4c75f2" />
+        </Fab>
+      </div>
     </div>
   );
 }

--- a/src/components/patientdb.js
+++ b/src/components/patientdb.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import {format, subDays} from 'date-fns';
 import DatePicker from 'react-date-picker';
 import * as Icon from 'react-feather';
-import Fab from '@material-ui/core/Fab';
+import {Fab, Fade} from '@material-ui/core';
 
 import Patients from './patients';
 import DownloadBlock from './downloadblock';
@@ -102,11 +102,11 @@ function PatientDB(props) {
   }
 
   const checkScrollEvent = useCallback((event) => {
-    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+    window.pageYOffset > 100 ? setHasScrolled(true) : setHasScrolled(false);
   }, []);
 
   useEffect(() => {
-    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+    window.pageYOffset > 100 ? setHasScrolled(true) : setHasScrolled(false);
     window.addEventListener('scroll', checkScrollEvent);
     return () => {
       window.removeEventListener('scroll', checkScrollEvent);
@@ -114,11 +114,8 @@ function PatientDB(props) {
   }, [hasScrolled, checkScrollEvent]);
 
   function animateScroll() {
-    const c = document.body.scrollTop || document.documentElement.scrollTop; // For {Safari} || {Chrome, Firefox, IE and Opera}
-    if (c > 0) {
-      window.requestAnimationFrame(animateScroll);
-      window.scrollTo(0, c - c / 6); // Increase fixed constant for smoother scrolling and vice versa
-    }
+    document.body.scrollTo({top: 0, behavior: 'smooth'}); // For Safari
+    document.documentElement.scrollTo({top: 0, behavior: 'smooth'}); // For Chrome, Firefox, IE and Opera
   }
 
   return (
@@ -377,23 +374,23 @@ function PatientDB(props) {
       <DownloadBlock patients={patients} />
 
       <div>
-        <Fab
-          color="inherit"
-          aria-label="gototop"
-          id="gototopbtn-patients"
-          onClick={animateScroll}
-          size="small"
-          disabled={!hasScrolled}
-          style={{
-            position: 'fixed',
-            bottom: '1rem',
-            right: '1rem',
-            zIndex: '1000',
-            opacity: hasScrolled ? 1 : 0,
-          }}
-        >
-          <Icon.Navigation2 strokeWidth="2.5" color="#4c75f2" />
-        </Fab>
+        <Fade in={hasScrolled}>
+          <Fab
+            color="inherit"
+            aria-label="gototop"
+            id="gototopbtn-patients"
+            onClick={animateScroll}
+            size="small"
+            style={{
+              position: 'fixed',
+              bottom: '1rem',
+              right: '1rem',
+              zIndex: '1000',
+            }}
+          >
+            <Icon.Navigation2 strokeWidth="2.5" color="#4c75f2" />
+          </Fab>
+        </Fade>
       </div>
     </div>
   );

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -1,8 +1,9 @@
 import axios from 'axios';
 import {format, parse} from 'date-fns';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useRef, useState, useCallback} from 'react';
 import {Link, useParams} from 'react-router-dom';
 import * as Icon from 'react-feather';
+import Fab from '@material-ui/core/Fab';
 
 import {
   formatDateAbsolute,
@@ -35,6 +36,7 @@ function State(props) {
   const [sources, setSources] = useState({});
   const [districtData, setDistrictData] = useState({});
   const [stateName] = useState(STATE_CODES[stateCode]);
+  const [hasScrolled, setHasScrolled] = useState(false);
 
   useEffect(() => {
     if (fetched === false) {
@@ -78,6 +80,26 @@ function State(props) {
       console.log(err);
     }
   };
+
+  const checkScrollEvent = useCallback((event) => {
+    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+  }, []);
+
+  useEffect(() => {
+    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+    window.addEventListener('scroll', checkScrollEvent);
+    return () => {
+      window.removeEventListener('scroll', checkScrollEvent);
+    };
+  }, [hasScrolled, checkScrollEvent]);
+
+  function animateScroll() {
+    const c = document.body.scrollTop || document.documentElement.scrollTop; // For {Safari} || {Chrome, Firefox, IE and Opera}
+    if (c > 0) {
+      window.requestAnimationFrame(animateScroll);
+      window.scrollTo(0, c - c / 6); // Increase fixed constant for smoother scrolling and vice versa
+    }
+  }
 
   const testObjLast = testData[testData.length - 1];
 
@@ -320,6 +342,26 @@ function State(props) {
         </div>
 
         <div className="state-right"></div>
+
+        <div>
+          <Fab
+            color="inherit"
+            aria-label="gototop"
+            id="gototopbtn-home"
+            onClick={animateScroll}
+            size="small"
+            disabled={!hasScrolled}
+            style={{
+              position: 'fixed',
+              bottom: '1rem',
+              right: '1rem',
+              zIndex: '1000',
+              opacity: hasScrolled ? 1 : 0,
+            }}
+          >
+            <Icon.Navigation2 strokeWidth="2.5" color="#4c75f2" />
+          </Fab>
+        </div>
       </div>
       <Footer />
     </React.Fragment>

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -3,7 +3,7 @@ import {format, parse} from 'date-fns';
 import React, {useEffect, useRef, useState, useCallback} from 'react';
 import {Link, useParams} from 'react-router-dom';
 import * as Icon from 'react-feather';
-import Fab from '@material-ui/core/Fab';
+import {Fab, Fade} from '@material-ui/core';
 
 import {
   formatDateAbsolute,
@@ -82,11 +82,11 @@ function State(props) {
   };
 
   const checkScrollEvent = useCallback((event) => {
-    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+    window.pageYOffset > 100 ? setHasScrolled(true) : setHasScrolled(false);
   }, []);
 
   useEffect(() => {
-    window.pageYOffset > 20 ? setHasScrolled(true) : setHasScrolled(false);
+    window.pageYOffset > 100 ? setHasScrolled(true) : setHasScrolled(false);
     window.addEventListener('scroll', checkScrollEvent);
     return () => {
       window.removeEventListener('scroll', checkScrollEvent);
@@ -94,11 +94,8 @@ function State(props) {
   }, [hasScrolled, checkScrollEvent]);
 
   function animateScroll() {
-    const c = document.body.scrollTop || document.documentElement.scrollTop; // For {Safari} || {Chrome, Firefox, IE and Opera}
-    if (c > 0) {
-      window.requestAnimationFrame(animateScroll);
-      window.scrollTo(0, c - c / 6); // Increase fixed constant for smoother scrolling and vice versa
-    }
+    document.body.scrollTo({top: 0, behavior: 'smooth'}); // For Safari
+    document.documentElement.scrollTo({top: 0, behavior: 'smooth'}); // For Chrome, Firefox, IE and Opera
   }
 
   const testObjLast = testData[testData.length - 1];
@@ -344,23 +341,23 @@ function State(props) {
         <div className="state-right"></div>
 
         <div>
-          <Fab
-            color="inherit"
-            aria-label="gototop"
-            id="gototopbtn-home"
-            onClick={animateScroll}
-            size="small"
-            disabled={!hasScrolled}
-            style={{
-              position: 'fixed',
-              bottom: '1rem',
-              right: '1rem',
-              zIndex: '1000',
-              opacity: hasScrolled ? 1 : 0,
-            }}
-          >
-            <Icon.Navigation2 strokeWidth="2.5" color="#4c75f2" />
-          </Fab>
+          <Fade in={hasScrolled}>
+            <Fab
+              color="inherit"
+              aria-label="gototop"
+              id="gototopbtn-home"
+              onClick={animateScroll}
+              size="small"
+              style={{
+                position: 'fixed',
+                bottom: '1rem',
+                right: '1rem',
+                zIndex: '1000',
+              }}
+            >
+              <Icon.Navigation2 strokeWidth="2.5" color="#4c75f2" />
+            </Fab>
+          </Fade>
         </div>
       </div>
       <Footer />


### PR DESCRIPTION
**Description of PR**
- Scroll Buttons for Home, Demographics and State pages<sup>1</sup>
- Uses Feather Icons (w/ color palette from App.scss)
- Animated Scroll
- Scroll Button only appears when user has scrolled down the page

<sup>1</sup>Button is implemented for the Essentials page too but that'll feature in a later release


**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes issue #1273 
Note: Saw PR #1274 already solves the issue but I preempted more issues being raised for the other pages. Also the animation fits in well

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
_Home_
![scroll_home](https://user-images.githubusercontent.com/25769767/79698642-4bb64680-829b-11ea-8546-2730e55128d5.gif)

_Patients DB_
![scroll_patients](https://user-images.githubusercontent.com/25769767/79698629-3e995780-829b-11ea-884c-6e89d10befd0.gif)

_State (eg. MH)_
![scroll_state](https://user-images.githubusercontent.com/25769767/79698625-36411c80-829b-11ea-8d32-2ac0425195ce.gif)

