### PR TITLE
Home Page and State Page : Daily Active chart showing negative values

### DIFF
--- a/src/components/minigraph.js
+++ b/src/components/minigraph.js
@@ -25,7 +25,10 @@ function Minigraph({timeseries}) {
     const svg4 = d3.select(svgRef4.current);
 
     data.forEach((d) => {
-      d['dailyactive'] = d.dailyconfirmed - d.dailyrecovered - d.dailydeceased;
+      d['dailyactive'] =
+        d.dailyconfirmed - d.dailyrecovered - d.dailydeceased > 0
+          ? d.dailyconfirmed - d.dailyrecovered - d.dailydeceased
+          : 0;
     });
 
     const xScale = d3

--- a/src/utils/common-functions.js
+++ b/src/utils/common-functions.js
@@ -111,6 +111,15 @@ export const parseStateTimeseries = ({states_daily: data}) => {
           +data[i + 1][stateCode] + (prev.totalrecovered || 0);
         const totaldeceased =
           +data[i + 2][stateCode] + (prev.totaldeceased || 0);
+
+        // Active = Confimed - Recovered - Deceased
+
+        let totalactive = totalconfirmed - totalrecovered - totaldeceased;
+        totalactive = totalactive > 0 ? totalactive : 0;
+
+        let dailyactive = dailyconfirmed - dailyrecovered - dailydeceased;
+        dailyactive = dailyactive > 0 ? dailyactive : 0;
+
         // Push
         v.push({
           date: date.toDate(),
@@ -120,9 +129,8 @@ export const parseStateTimeseries = ({states_daily: data}) => {
           totalconfirmed: totalconfirmed,
           totalrecovered: totalrecovered,
           totaldeceased: totaldeceased,
-          // Active = Confimed - Recovered - Deceased
-          totalactive: totalconfirmed - totalrecovered - totaldeceased,
-          dailyactive: dailyconfirmed - dailyrecovered - dailydeceased,
+          totalactive: totalactive,
+          dailyactive: dailyactive,
         });
       });
     }


### PR DESCRIPTION
**Description of PR**
This PR Fixes the daily active cases graph which was showing the negative values if the recovery was greater than active cases that day.

**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes #1313 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Before : 
![image](https://user-images.githubusercontent.com/11074737/79701090-df960b80-82b7-11ea-8ab6-d6b7685cc8fe.png)

After : 
![image](https://user-images.githubusercontent.com/11074737/79701107-ffc5ca80-82b7-11ea-9e78-65bc7fc260d8.png)

