### PR TITLE
Improv: Make legends in Demographics to filter

### DIFF
--- a/src/components/patientdb.js
+++ b/src/components/patientdb.js
@@ -20,6 +20,7 @@ function filterByObject(obj, filters) {
 
 function PatientDB(props) {
   const [fetched, setFetched] = useState(false);
+  const [patientGender, setPatientGender] = useState('default');
   const [patients, setPatients] = useState([]);
   const [filteredPatients, setFilteredPatients] = useState([]);
   const [error, setError] = useState('');
@@ -247,11 +248,29 @@ function PatientDB(props) {
           {colorMode === 'genders' && (
             <div className="legend-left">
               <div className="circle is-female"></div>
-              <h5 className="is-female">Female</h5>
+              <h5
+                className="is-female"
+                style={{cursor: 'pointer'}}
+                onClick={() => setPatientGender('F')}
+              >
+                <u>Female</u>
+              </h5>
               <div className="circle is-male"></div>
-              <h5 className="is-male">Male</h5>
+              <h5
+                className="is-male"
+                style={{cursor: 'pointer'}}
+                onClick={() => setPatientGender('M')}
+              >
+                <u>Male</u>
+              </h5>
               <div className="circle"></div>
-              <h5 className="">Unknown</h5>
+              <h5
+                className=""
+                style={{cursor: 'pointer'}}
+                onClick={() => setPatientGender('')}
+              >
+                <u>Unknown</u>
+              </h5>
             </div>
           )}
 
@@ -294,11 +313,9 @@ function PatientDB(props) {
               style={{animationDelay: '0.4s'}}
               onChange={(event) => {
                 setColorMode(event.target.value);
+                setPatientGender('default');
               }}
             >
-              <option value="" disabled selected>
-                Color modes
-              </option>
               <option value="genders">Genders</option>
               <option value="transmission">Transmission</option>
               <option value="nationality">Nationality</option>
@@ -349,6 +366,7 @@ function PatientDB(props) {
           patients={filteredPatients}
           colorMode={colorMode}
           expand={scaleMode}
+          patientGenderForFilter={patientGender}
         />
       </div>
       <DownloadBlock patients={patients} />

--- a/src/components/patients.js
+++ b/src/components/patients.js
@@ -128,6 +128,8 @@ function Patients(props) {
         setPatient={setPatient}
         expand={props.expand}
         applyClass={getClassNameFn(props.colorMode)}
+        patientGender={props.patientGenderForFilter}
+        colorMode={props.colorMode}
       />
 
       {modal && (

--- a/src/components/patientsview.js
+++ b/src/components/patientsview.js
@@ -20,24 +20,88 @@ function PatientsView(props) {
                   key={index}
                   className={`day ${props.summary ? 'summary' : ''}`}
                 >
-                  {logs[day]
-                    .slice(props.summary ? -40 : 0)
-                    .map((patient, indexTwo) => {
-                      return (
-                        <div
-                          key={indexTwo}
-                          className={props.applyClass(patient)}
-                          onClick={() => {
-                            props.setModal(true);
-                            props.setPatient(patient);
-                          }}
-                        >
-                          <h3>
-                            {props.expand ? `P${patient.patientnumber}` : ''}
-                          </h3>
-                        </div>
-                      );
-                    })}
+                  {props.colorMode === 'genders' &&
+                    props.patientGender === 'default' &&
+                    logs[day]
+                      .slice(props.summary ? -40 : 0)
+                      .map((patient, indexTwo) => {
+                        console.log(patient);
+                        return (
+                          <div
+                            key={indexTwo}
+                            className={props.applyClass(patient)}
+                            onClick={() => {
+                              props.setModal(true);
+                              props.setPatient(patient);
+                            }}
+                          >
+                            <h3>
+                              {props.expand ? `P${patient.patientnumber}` : ''}
+                            </h3>
+                          </div>
+                        );
+                      })}
+                  {props.colorMode === 'genders' &&
+                    logs[day]
+                      .slice(props.summary ? -40 : 0)
+                      .filter(
+                        (patient) => patient.gender === props.patientGender
+                      )
+                      .map((patient, indexTwo) => {
+                        console.log(patient);
+                        return (
+                          <div
+                            key={indexTwo}
+                            className={props.applyClass(patient)}
+                            onClick={() => {
+                              props.setModal(true);
+                              props.setPatient(patient);
+                            }}
+                          >
+                            <h3>
+                              {props.expand ? `P${patient.patientnumber}` : ''}
+                            </h3>
+                          </div>
+                        );
+                      })}
+                  {props.colorMode === 'transmission' &&
+                    logs[day]
+                      .slice(props.summary ? -40 : 0)
+                      .map((patient, indexTwo) => {
+                        return (
+                          <div
+                            key={indexTwo}
+                            className={props.applyClass(patient)}
+                            onClick={() => {
+                              props.setModal(true);
+                              props.setPatient(patient);
+                            }}
+                          >
+                            <h3>
+                              {props.expand ? `P${patient.patientnumber}` : ''}
+                            </h3>
+                          </div>
+                        );
+                      })}
+                  {props.colorMode === 'nationality' &&
+                    logs[day]
+                      .slice(props.summary ? -40 : 0)
+                      .map((patient, indexTwo) => {
+                        return (
+                          <div
+                            key={indexTwo}
+                            className={props.applyClass(patient)}
+                            onClick={() => {
+                              props.setModal(true);
+                              props.setPatient(patient);
+                            }}
+                          >
+                            <h3>
+                              {props.expand ? `P${patient.patientnumber}` : ''}
+                            </h3>
+                          </div>
+                        );
+                      })}
                 </div>
               </React.Fragment>
             );


### PR DESCRIPTION
Co-authored-by: Gyanendra Patro <gyanendrapatro02@gmail.com>

**Description of PR**
Fixing gender demographics to show gender-specific data on click of different genders.
On right header section of Demographics, page legends must be selectable
In Header on any selected colour modes (ex. Gender) its legends (Male, Female, Unknown) also have tappable functionality so that user can filter Patient-Cards Infographic on selected legend basis.


**Type of PR**
- [x] Enhacement

**Relevant Issues**  
Fixes #1253 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![image](https://user-images.githubusercontent.com/49842562/79722094-18a69e00-8301-11ea-98ff-1af1454b1c59.png)
![image](https://user-images.githubusercontent.com/49842562/79722159-2f4cf500-8301-11ea-9e31-13cecb81ba92.png)
