### PR TITLE
Removed Active Cases Chart from Daily Section

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -416,7 +416,10 @@ function TimeSeries(props) {
           </svg>
         </div>
 
-        <div className="svg-parent is-blue">
+        <div
+          className="svg-parent is-blue"
+          style={{display: chartType === 1 ? '' : 'none'}}
+        >
           <div className="stats is-blue">
             <h5 className={`${!moving ? 'title' : ''}`}>Active</h5>
             <h5 className={`${moving ? 'title' : ''}`}>{`${dateStr}`}</h5>


### PR DESCRIPTION
**Description of PR**
This PR Fixes the daily active cases graph which was showing the negative values if the recovery was greater than active cases that day.

**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes #1313 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
before:
![before](https://user-images.githubusercontent.com/47060625/79723202-fb72cf00-8302-11ea-8c96-2c701790de93.jpg)
after:
![after](https://user-images.githubusercontent.com/47060625/79723228-0463a080-8303-11ea-8822-7384bd79b4bb.jpg)
