### PR TITLE
Fix: Separate x-axis of timeseries charts from zero axis

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -92,11 +92,21 @@ function TimeSeries(props) {
       // Number of x-axis ticks
       const numTicksX = width < 480 ? 4 : 7;
 
-      const xAxis = (g, yScale) =>
+      const xAxis = (g) =>
         g
           .attr('class', 'x-axis')
           .call(d3.axisBottom(xScale).ticks(numTicksX))
+          .style('transform', `translateY(${chartBottom}px)`);
+
+      const xAxis2 = (g, yScale) => {
+        g.attr('class', 'x-axis2')
+          .call(d3.axisBottom(xScale).tickValues([]).tickSize(0))
+          .select('.domain')
           .style('transform', `translateY(${yScale(0)}px)`);
+
+        if (yScale(0) !== chartBottom) g.select('.domain').attr('opacity', 0.4);
+        else g.select('.domain').attr('opacity', 0);
+      };
 
       const yAxis = (g, yScale) =>
         g
@@ -181,10 +191,11 @@ function TimeSeries(props) {
           .scaleLinear()
           .clamp(true)
           .domain([
-            Math.min(
-              0,
-              d3.min(timeseries, (d) => d.dailyactive)
-            ),
+            yBuffer *
+              Math.min(
+                0,
+                d3.min(timeseries, (d) => d.dailyactive)
+              ),
             Math.max(
               1,
               yBuffer *
@@ -201,10 +212,11 @@ function TimeSeries(props) {
             .scaleLinear()
             .clamp(true)
             .domain([
-              Math.min(
-                0,
-                d3.min(timeseries, (d) => d[type])
-              ),
+              yBuffer *
+                Math.min(
+                  0,
+                  d3.min(timeseries, (d) => d[type])
+                ),
               Math.max(1, yBuffer * d3.max(timeseries, (d) => d[type])),
             ])
             .nice()
@@ -270,7 +282,8 @@ function TimeSeries(props) {
         const yScale = yScales[i];
 
         /* X axis */
-        svg.select('.x-axis').transition(t).call(xAxis, yScale);
+        svg.select('.x-axis').transition(t).call(xAxis);
+        svg.select('.x-axis2').transition(t).call(xAxis2, yScale);
         /* Y axis */
         svg.select('.y-axis').transition(t).call(yAxis, yScale);
 
@@ -412,6 +425,7 @@ function TimeSeries(props) {
           </div>
           <svg ref={svgRef1} preserveAspectRatio="xMidYMid meet">
             <g className="x-axis" />
+            <g className="x-axis2" />
             <g className="y-axis" />
           </svg>
         </div>
@@ -427,6 +441,7 @@ function TimeSeries(props) {
           </div>
           <svg ref={svgRef2} preserveAspectRatio="xMidYMid meet">
             <g className="x-axis" />
+            <g className="x-axis2" />
             <g className="y-axis" />
           </svg>
         </div>
@@ -442,6 +457,7 @@ function TimeSeries(props) {
           </div>
           <svg ref={svgRef3} preserveAspectRatio="xMidYMid meet">
             <g className="x-axis" />
+            <g className="x-axis2" />
             <g className="y-axis" />
           </svg>
         </div>
@@ -457,6 +473,7 @@ function TimeSeries(props) {
           </div>
           <svg ref={svgRef4} preserveAspectRatio="xMidYMid meet">
             <g className="x-axis" />
+            <g className="x-axis2" />
             <g className="y-axis" />
           </svg>
         </div>


### PR DESCRIPTION
**Description of PR**
- Move primary date axis back to the bottom
- Add a secondary translucent axis to show zero line

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #1335

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![image](https://user-images.githubusercontent.com/27727946/79751939-12c8b100-8331-11ea-98b6-10d349a90289.png)
