### PR TITLE
no background scrolling when menu is opened in mobile devices

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -141,6 +141,9 @@ body {
   margin: 0;
   -webkit-tap-highlight-color: transparent;
   -webkit-touch-callout: none;
+  &.noscroll {
+    overflow: hidden;
+  }
 }
 
 h1 {

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {Link} from 'react-router-dom';
 
 const navLinkProps = (path, animationDelay) => ({
@@ -10,6 +10,12 @@ const navLinkProps = (path, animationDelay) => ({
 
 function Navbar({pages}) {
   const [expand, setExpand] = useState(false);
+
+  useEffect(() => {
+    const body = document.body;
+    if (window.innerWidth <= 769) body.classList.toggle('noscroll', expand);
+    else body.classList.toggle('noscroll', false);
+  }, [expand]);
 
   return (
     <div


### PR DESCRIPTION
**Description of PR**
In mobile devices, when menu is expanded, the background main content should not be scrollable.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #1311

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
### before
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/11428805/79773620-4ca8b000-834f-11ea-860a-d3ec32fd096d.gif)
### after
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/11428805/79773643-5500eb00-834f-11ea-993b-0415f944ab99.gif)


