### PR TITLE
Fix: Set z-index of stats in timeseries to avoid pointer events on scrub.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2245,6 +2245,7 @@ input.switch:checked::after {
     border-radius: 3px;
     display: flex;
     flex-direction: column;
+    z-index: -1;
 
     h2,
     h5,


### PR DESCRIPTION
**Description of PR**
This PR fix the issue when you hover over stats in timeseries charts.
**Before**: the hover action over stats doesn't make appropriate changes in focus dot rather it resets the same. 
**After**: the hover action makes appropriate changes around all the regions in timeseries including stats region.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #1347  

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
**Before**
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/11428805/79804538-d96c6180-8381-11ea-895a-e1c73de4f061.gif)
**After**
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/11428805/79805072-fe150900-8382-11ea-8bb3-7af9e8ccdd78.gif)

