### PR TITLE
Improv: Add message for no results in Demographics

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2739,16 +2739,19 @@ footer {
     .react-date-picker__calendar-button {
       padding: 0 !important;
       margin: 0 !important;
-      margin-left: 0.5rem !important;
+      margin-left: 0.25rem !important;
       svg {
         height: 16px;
         width: 16px;
+        stroke-width: 3px;
       }
     }
 
-    .calendar-close {
-      width: 12px;
-      stroke-width: 3;
+    .react-date-picker__clear-button {
+      svg {
+        width: 16px;
+        stroke-width: 3px;
+      }
     }
 
     select {
@@ -2840,6 +2843,25 @@ footer {
   .patientdb-wrapper {
     padding-left: 5rem;
     padding-right: 5rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    .no-result {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      height: 20rem;
+      align-self: center;
+      h5 {
+        color: $gray;
+        text-align: center;
+        font-weight: 600;
+        span {
+          font-weight: 900;
+          color: $pblue !important;
+        }
+      }
+    }
   }
 
   .legend {

--- a/src/components/patientdb.js
+++ b/src/components/patientdb.js
@@ -29,6 +29,8 @@ function PatientDB(props) {
   const [scaleMode, setScaleMode] = useState(false);
   const [filterDate, setFilterDate] = useState(subDays(new Date(), 1));
   const [showReminder, setShowReminder] = useLocalStorage('showReminder', true);
+  const [message, setMessage] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [filters, setFilters] = useState({
     detectedstate: '',
     detecteddistrict: '',
@@ -91,7 +93,13 @@ function PatientDB(props) {
   };
 
   useEffect(() => {
-    setFilteredPatients(filterByObject(patients, filters));
+    if (filterByObject(patients, filters).length > 0) {
+      setFilteredPatients(filterByObject(patients, filters));
+      setMessage(false);
+      setLoading(false);
+    } else {
+      setMessage(true);
+    }
   }, [patients, filters]);
 
   function getSortedValues(obj, key) {
@@ -224,8 +232,7 @@ function PatientDB(props) {
                   e.preventDefault();
                 })
               }
-              clearIcon={<Icon.XCircle size={16} />}
-              className={'calendar-close'}
+              clearIcon={<Icon.XCircle />}
               onChange={(date) => {
                 setFilterDate(date);
                 const fomattedDate = !!date ? format(date, 'dd/MM/yyyy') : '';
@@ -365,11 +372,31 @@ function PatientDB(props) {
 
       {fetched && (
         <div className="patientdb-wrapper">
-          <Patients
-            patients={filteredPatients}
-            colorMode={colorMode}
-            expand={scaleMode}
-          />
+          {loading ? (
+            ' '
+          ) : message ? (
+            <div className="no-result">
+              <h5>
+                There were no new cases in
+                <span>
+                  {filters.detectedcity.length > 0
+                    ? ` ${filters.detectedcity}, `
+                    : ''}
+                  {filters.detecteddistrict.length > 0
+                    ? ` ${filters.detecteddistrict}, `
+                    : ''}
+                  {' ' + filters.detectedstate}
+                </span>{' '}
+                on <span>{filters.dateannounced}.</span>
+              </h5>
+            </div>
+          ) : (
+            <Patients
+              patients={filteredPatients}
+              colorMode={colorMode}
+              expand={scaleMode}
+            />
+          )}
         </div>
       )}
 


### PR DESCRIPTION
**Description of PR**
In Demographics when a search is done resulting in no new cases, then currently previously fetched data is shown, added a message to prompt the user to modify search.
This issue had been opened 13 days ago, and still unresolved, that's why I have made a PR, sorry if it against the code of conduct, no bad intention.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #789 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
<img width="587" alt="Screen Shot 2020-04-22 at 8 30 55 PM" src="https://user-images.githubusercontent.com/17938322/80013849-31b57780-84d8-11ea-8cda-c9eaaaf21e2f.png">
