### PR TITLE
Fix: Resolve bloodhound search on initial load or first remote query.

### DIFF
--- a/src/components/search.js
+++ b/src/components/search.js
@@ -95,7 +95,7 @@ function Search(props) {
     };
 
     const essentialsAsync = (datums) => {
-      // to handle async remote call
+      // to handle async remote call on initial launch
       essentialsEngine.search(searchInput, essentialsSync);
     };
 

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -90,13 +90,18 @@ function Search(props) {
           contact: result.phonenumber,
         };
         results.push(essentialsObj);
-        return null;
       });
+      setResults([...results]);
+    };
+
+    const essentialsAsync = (datums) => {
+      // to handle async remote call
+      essentialsEngine.search(searchInput, essentialsSync);
     };
 
     engine.search(searchInput, sync);
     districtEngine.search(searchInput, districtSync);
-    essentialsEngine.search(searchInput, essentialsSync);
+    essentialsEngine.search(searchInput, essentialsSync, essentialsAsync);
     setResults(results);
   }, []);
 

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -102,7 +102,6 @@ function Search(props) {
     engine.search(searchInput, sync);
     districtEngine.search(searchInput, districtSync);
     essentialsEngine.search(searchInput, essentialsSync, essentialsAsync);
-    setResults(results);
   }, []);
 
   function setNativeValue(element, value) {


### PR DESCRIPTION
**Description of PR**
The search bar on the homepage for searching cities, essentials, wasn't working fine on selecting something from predefined essentials from the given list.

Even after selecting an essential thing, the search didn’t happen, I've tried the enter key from keyboard or clicking the search icon nothing worked.

So, in order to fix this bug, I went through the [typeahead library](https://github.com/corejavascript/typeahead.js) which we're using in this project and got to know about the problem. And the problem was the remote data fetching is an asynchronous task and we were trying to handle it with a normal synchronous function. I just fixed it.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #...

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![ezgif com-optimize (1)](https://user-images.githubusercontent.com/18095705/79861069-6995bf80-83f1-11ea-994b-4c6d5f5fbeb4.gif)