### PR TITLE
Fix: Tooltip info out of screen issue

### DIFF
--- a/src/components/row.js
+++ b/src/components/row.js
@@ -1,3 +1,5 @@
+import Tooltip from './tooltip';
+
 import {
   formatDate,
   formatDateAbsolute,
@@ -7,7 +9,6 @@ import {
 import {formatDistance} from 'date-fns';
 import React, {useState, useEffect, useCallback} from 'react';
 import * as Icon from 'react-feather';
-import {Tooltip} from 'react-lightweight-tooltip';
 import {Link} from 'react-router-dom';
 
 function Row(props) {
@@ -34,17 +35,7 @@ function Row(props) {
 
   const tooltipStyles = {
     tooltip: {
-      background: '#000',
-      borderRadius: '10px',
-      fontSize: '.8em',
       left: '250%',
-      opacity: 0.65,
-    },
-    wrapper: {
-      cursor: 'cursor',
-      display: 'inline-block',
-      position: 'relative',
-      textAlign: 'center',
     },
     arrow: {
       left: '37%',
@@ -106,6 +97,19 @@ function Row(props) {
     localStorage.setItem('district.isAscending', isAscending);
   };
 
+  const getTooltipStyles = (index) => {
+    const tooltip = document.getElementById('tooltip-' + index);
+    if (tooltip !== null) {
+      const tooltipLeft = tooltip.getBoundingClientRect().left;
+      const tooltipContentLeft = tooltipLeft - 70;
+      if (tooltipContentLeft < 2) {
+        tooltipStyles.tooltip.marginLeft = -tooltipContentLeft + 2 + 'px';
+        tooltipStyles.arrow.marginLeft = tooltipLeft - 77 + 'px';
+      }
+    }
+    return tooltipStyles;
+  };
+
   useEffect(() => {
     sortDistricts(districts);
   }, [districts, sortData, sortDistricts]);
@@ -137,10 +141,10 @@ function Row(props) {
             <span className="actual__title-wrapper">
               {state.state}
               {state.statenotes && (
-                <span onClick={handleTooltip}>
+                <span onClick={handleTooltip} id={'tooltip-' + props.index}>
                   <Tooltip
                     content={[`${state.statenotes}`]}
-                    styles={tooltipStyles}
+                    styles={getTooltipStyles(props.index)}
                   >
                     <Icon.Info />
                   </Tooltip>

--- a/src/components/tooltip.js
+++ b/src/components/tooltip.js
@@ -1,0 +1,125 @@
+import React, {useState, useEffect, useRef} from 'react';
+
+function Tooltip(props) {
+  const [styles, setStyles] = useState({});
+  const [visible, setVisibility] = useState(false);
+
+  const wrapper = useRef(null);
+  const tooltip = useRef(null);
+  const content = useRef(null);
+  const arrow = useRef(null);
+  const gap = useRef(null);
+
+  const baseStyles = {
+    wrapper: {
+      position: 'relative',
+      display: 'inline-block',
+      zIndex: '98',
+      color: '#555',
+      cursor: 'cursor',
+    },
+    tooltip: {
+      position: 'absolute',
+      zIndex: '99',
+      minWidth: '200px',
+      maxWidth: '420px',
+      background: '#000',
+      bottom: '100%',
+      left: '50%',
+      marginBottom: '10px',
+      padding: '5px',
+      WebkitTransform: 'translateX(-50%)',
+      msTransform: 'translateX(-50%)',
+      OTransform: 'translateX(-50%)',
+      transform: 'translateX(-50%)',
+      opacity: 1,
+      fontSize: '1rem',
+      textAlign: 'center',
+      paddingBottom: '0.5rem',
+      borderRadius: '5px',
+    },
+    content: {
+      background: '#000',
+      color: '#fff',
+      display: 'inline',
+      fontSize: '.8em',
+    },
+    arrow: {
+      position: 'absolute',
+      width: '0',
+      height: '0',
+      bottom: '-5px',
+      left: '50%',
+      marginLeft: '-5px',
+      borderLeft: 'solid transparent 5px',
+      borderRight: 'solid transparent 5px',
+      borderTop: 'solid #000 5px',
+    },
+    gap: {
+      position: 'absolute',
+      width: '100%',
+      height: '20px',
+      bottom: '-20px',
+    },
+  };
+
+  useEffect(() => {
+    const mergeStyles = (userStyles) => {
+      const newStyles = {};
+      Object.keys(baseStyles).forEach((name) => {
+        newStyles[name] = Object.assign({}, baseStyles[name], userStyles[name]);
+      });
+      return newStyles;
+    };
+    setStyles(mergeStyles(props.styles));
+  }, [baseStyles, props.styles]);
+
+  const show = () => setVisibility(true);
+
+  const hide = () => setVisibility(false);
+
+  const handleTouch = () => {
+    show();
+    assignOutsideTouchHandler();
+  };
+
+  const componentNode = useRef(null);
+  const assignOutsideTouchHandler = () => {
+    const handler = (e) => {
+      let currentNode = e.target;
+      while (currentNode.parentNode) {
+        if (currentNode === componentNode) return;
+        currentNode = currentNode.parentNode;
+      }
+      if (currentNode !== document) return;
+      hide();
+      document.removeEventListener('touchstart', handler);
+    };
+    document.addEventListener('touchstart', handler);
+  };
+
+  return (
+    <React.Fragment>
+      <div
+        onMouseEnter={show}
+        onMouseLeave={hide}
+        onTouchStart={handleTouch}
+        ref={wrapper}
+        style={styles.wrapper}
+      >
+        {props.children}
+        {visible && (
+          <div ref={tooltip} style={styles.tooltip}>
+            <div ref={content} style={styles.content}>
+              {props.content}
+            </div>
+            <div ref={arrow} style={styles.arrow} />
+            <div ref={gap} style={styles.gap} />
+          </div>
+        )}
+      </div>
+    </React.Fragment>
+  );
+}
+
+export default React.memo(Tooltip);


### PR DESCRIPTION
**Description of PR**
The PR fixes the issue when tooltip info gets out of the screen. To solve this, I had to rewrite tooltip component making some modifications to support re-render of tooltip component on change of props. I have transformed it to use react hooks.

**Type of PR**

- [x] Bugfix
- [ ] New feature

**Relevant Issues**  
Fixes #1380 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
### Before
![Screenshot (36)](https://user-images.githubusercontent.com/11428805/79997093-cd45e880-84d6-11ea-9649-e8f9e5765ba9.png)

### After
![Screenshot (34)](https://user-images.githubusercontent.com/11428805/79997105-d0d96f80-84d6-11ea-95c5-fa21d8b764e7.png)
