### PR TITLE
Feat: Add maps based on active, recovered, and deceased counts

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -429,11 +429,15 @@ h6 {
     width: 100%;
   }
 
-  .Minigraph,
-  .Level,
   .MapExplorer,
   .meta-secondary {
     width: calc(100% - 3rem);
+  }
+
+  .Minigraph {
+    .svg-parent {
+      width: calc(25%) !important;
+    }
   }
 
   .MapExplorer {
@@ -1357,17 +1361,9 @@ h6 {
   .clickable {
     border-radius: 5px;
     cursor: pointer;
-    height: 10.5rem;
-    width: 7rem;
+    height: 12rem;
+    width: calc(25%);
     z-index: 10;
-
-    &:first-child {
-      margin-left: .5rem;
-    }
-
-    &:last-child {
-      margin-right: .5rem;
-    }
   }
 }
 
@@ -1382,17 +1378,10 @@ h6 {
   .level-item {
     display: flex;
     flex-direction: column;
+    width: calc(25%);
 
     & > * {
       align-self: center;
-    }
-
-    &:first-child {
-      margin-left: .5rem;
-    }
-
-    &:last-child {
-      margin-right: .5rem;
     }
   }
 
@@ -2233,6 +2222,11 @@ table {
 .TimeSeries {
   align-self: center;
   width: 100%;
+
+  .svg-parent {
+    height: 10rem;
+    margin-bottom: 1rem;
+  }
 }
 
 .timeseries-header {
@@ -2379,7 +2373,6 @@ input {
   margin-top: 1rem;
   width: 100%;
 
-
   .stats {
     border-radius: 3px;
     display: flex;
@@ -2475,8 +2468,6 @@ input {
     background: $cherry-light;
     border-radius: 5px;
     display: flex;
-    height: 10rem;
-    margin-bottom: 1rem;
     position: relative;
     width: 30rem;
 
@@ -2554,13 +2545,13 @@ input {
   flex-direction: row;
   justify-content: space-between;
   margin: 0;
-  margin-bottom: -3rem;
+  margin-bottom: 1rem;
+  margin-top: 1rem;
   width: 30rem;
 
   .svg-parent {
     background: transparent !important;
-    height: 7rem;
-    width: 5rem;
+    width: calc(25%);
   }
 
   .tooltip {
@@ -4210,6 +4201,12 @@ footer {
   .TimeSeries {
     .svg-parent {
       width: 100%;
+    }
+  }
+
+  .Minigraph {
+    .svg-parent {
+      padding: 0;
     }
   }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -1986,7 +1986,6 @@ table {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    height: 3.5rem;
     margin-bottom: 1rem;
     position: relative;
     width: 100%;
@@ -2013,7 +2012,7 @@ table {
       flex: 1;
       flex-direction: column;
       height: 3rem;
-      margin-bottom: .5rem;
+      margin-bottom: 1rem;
       margin-left: .25rem;
       margin-right: .25rem;
       padding: .25rem;
@@ -2124,6 +2123,7 @@ table {
       }
 
       &.focused {
+        margin-bottom: .5rem;
         margin-top: -.5rem;
         padding-bottom: .75rem;
         padding-top: .75rem;

--- a/src/App.scss
+++ b/src/App.scss
@@ -437,6 +437,8 @@ h6 {
   }
 
   .MapExplorer {
+    margin-top: 2rem;
+
     .header,
     .map-stats,
     .back-button,
@@ -1320,6 +1322,52 @@ h6 {
 
   &:hover {
     background: #33a66750;
+  }
+}
+
+.map-switcher {
+  align-self: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  position: absolute;
+  top: 13rem;
+  width: 30rem;
+
+  .highlight {
+    background: $cherry-light;
+    position: absolute;
+    width: calc(25%) !important;
+    z-index: -1;
+
+    &.active {
+      background: $blue-light;
+    }
+
+    &.recovered {
+      background: $green-light;
+    }
+
+    &.deceased {
+      background: $gray-light;
+    }
+  }
+
+  .highlight,
+  .clickable {
+    border-radius: 5px;
+    cursor: pointer;
+    height: 10.5rem;
+    width: 7rem;
+    z-index: 10;
+
+    &:first-child {
+      margin-left: .5rem;
+    }
+
+    &:last-child {
+      margin-right: .5rem;
+    }
   }
 }
 
@@ -4124,6 +4172,7 @@ footer {
   .MapExplorer,
   .filters,
   .updates,
+  .map-switcher,
   .updates-header {
     width: calc(100% - 2rem);
   }

--- a/src/App.scss
+++ b/src/App.scss
@@ -1930,6 +1930,17 @@ table {
       font-weight: 900;
       margin: 0;
       word-wrap: break-word;
+      &.active {
+        color: $blue;
+      }
+
+      &.recovered {
+        color: $green;
+      }
+
+      &.deceased {
+        color: $gray;
+      }
     }
 
     h4 {
@@ -1938,13 +1949,24 @@ table {
       word-wrap: break-word;
     }
 
-    .district-confirmed {
+    .district {
       color: #e23028;
       line-height: 15px;
       margin: 0;
       position: absolute;
       top: 3rem;
       width: 5rem;
+      &.active {
+        color: $blue;
+      }
+
+      &.recovered {
+        color: $green;
+      }
+
+      &.deceased {
+        color: $gray;
+      }
     }
 
     .unknown {

--- a/src/App.scss
+++ b/src/App.scss
@@ -1855,6 +1855,7 @@ table {
   .map-hover {
     stroke: #ff073a;
     stroke-width: 2;
+
     &.active {
       stroke: #007bff;
     }
@@ -1930,6 +1931,7 @@ table {
       font-weight: 900;
       margin: 0;
       word-wrap: break-word;
+
       &.active {
         color: $blue;
       }
@@ -1956,6 +1958,7 @@ table {
       position: absolute;
       top: 3rem;
       width: 5rem;
+
       &.active {
         color: $blue;
       }
@@ -1983,11 +1986,11 @@ table {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
+    height: 3.5rem;
     margin-bottom: 1rem;
     position: relative;
     width: 100%;
     z-index: 10;
-    height: 3.5rem;
 
     h1,
     h5,
@@ -2005,17 +2008,17 @@ table {
       background: $cherry-light;
       border-radius: 5px;
       color: $cherry-mid;
+      cursor: pointer;
       display: flex;
+      flex: 1;
       flex-direction: column;
+      height: 3rem;
+      margin-bottom: .5rem;
       margin-left: .25rem;
       margin-right: .25rem;
-      margin-bottom: .5rem;
-      flex: 1;
       padding: .25rem;
       position: relative;
-      cursor: pointer;
-      height: 3rem;
-      transition: all 0.1s ease-in-out;
+      transition: all .1s ease-in-out;
 
       .stats-bottom {
         display: flex;
@@ -2122,8 +2125,8 @@ table {
 
       &.focused {
         margin-top: -.5rem;
-        padding-top: .75rem;
         padding-bottom: .75rem;
+        padding-top: .75rem;
       }
 
       &:first-child {

--- a/src/App.scss
+++ b/src/App.scss
@@ -1771,11 +1771,6 @@ table {
   z-index: 11;
 }
 
-.map-hover {
-  stroke: #ff073a;
-  stroke-width: 2;
-}
-
 .anchor {
   cursor: pointer;
   position: absolute;
@@ -1855,6 +1850,22 @@ table {
   .legend {
     margin-top: 1em;
     width: 100%;
+  }
+
+  .map-hover {
+    stroke: #ff073a;
+    stroke-width: 2;
+    &.active {
+      stroke: #007bff;
+    }
+
+    &.recovered {
+      stroke: #28a745;
+    }
+
+    &.deceased {
+      stroke: #6c757d;
+    }
   }
 
   .back-button {
@@ -1953,6 +1964,8 @@ table {
     margin-bottom: 1rem;
     position: relative;
     width: 100%;
+    z-index: 10;
+    height: 3.5rem;
 
     h1,
     h5,
@@ -1971,14 +1984,16 @@ table {
       border-radius: 5px;
       color: $cherry-mid;
       display: flex;
-      flex: 1;
       flex-direction: column;
-      margin-bottom: .5rem;
       margin-left: .25rem;
       margin-right: .25rem;
+      margin-bottom: .5rem;
+      flex: 1;
       padding: .25rem;
       position: relative;
-
+      cursor: pointer;
+      height: 3rem;
+      transition: all 0.1s ease-in-out;
 
       .stats-bottom {
         display: flex;
@@ -2081,6 +2096,12 @@ table {
             stroke: $purple;
           }
         }
+      }
+
+      &.focused {
+        margin-top: -.5rem;
+        padding-top: .75rem;
+        padding-bottom: .75rem;
       }
 
       &:first-child {

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -200,14 +200,14 @@ function ChoroplethMap({
       });
     },
     [
-      mapData,
       mapMeta,
       statistic,
-      changeMap,
-      setHoveredRegion,
-      setSelectedRegion,
-      isCountryLoaded,
       mapOption,
+      isCountryLoaded,
+      mapData,
+      setSelectedRegion,
+      setHoveredRegion,
+      changeMap,
     ]
   );
 

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -1,6 +1,7 @@
 import legend from './legend';
 
 import {MAP_TYPES} from '../constants';
+import {formatNumber} from '../utils/commonfunctions';
 
 import * as d3 from 'd3';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
@@ -102,8 +103,8 @@ function ChoroplethMap({
             ticks: 6,
             tickFormat: function (d, i, n) {
               if (!Number.isInteger(d)) return;
-              if (i === n.length - 1) return d + '+';
-              return d;
+              if (i === n.length - 1) return formatNumber(d) + '+';
+              return formatNumber(d);
             },
           })
         );

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -74,14 +74,14 @@ function ChoroplethMap({
             return d3.interpolateBlues(t * 0.85);
           case 'recovered':
             return d3.interpolateGreens(t * 0.85);
-          case 'deaths':
+          case 'deceased':
             return d3.interpolateGreys(t * 0.85);
           default:
             return;
         }
       };
       const colorScale = d3.scaleSequential(
-        [0, statistic[mapOption].max],
+        [0, Math.max(1, statistic[mapOption].max)],
         colorInterpolator
       );
       // Colorbar
@@ -89,18 +89,14 @@ function ChoroplethMap({
       const margin = {left: 0.02 * widthLegend, right: 0.02 * widthLegend};
       const barWidth = widthLegend - margin.left - margin.right;
       const heightLegend = +svgLegend.attr('height');
-      let legendTitle =
-        mapOption !== 'deaths'
-          ? mapOption.charAt(0).toUpperCase() + mapOption.slice(1)
-          : 'Deceased';
-      legendTitle += ' Cases';
       svgLegend
         .append('g')
         .style('transform', `translateX(${margin.left}px)`)
         .append(() =>
           legend({
             color: colorScale,
-            title: legendTitle,
+            title:
+              mapOption.charAt(0).toUpperCase() + mapOption.slice(1) + ' Cases',
             width: barWidth,
             height: 0.8 * heightLegend,
             ticks: 6,

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -171,7 +171,7 @@ function ChoroplethMap({
           }`
         )
         .attr('fill', 'none')
-        .attr('stroke-width', 2)
+        .attr('stroke-width', width / 200)
         .attr(
           'd',
           path(topojson.mesh(geoData, geoData.objects[mapMeta.graphObjectName]))

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -155,7 +155,20 @@ function ChoroplethMap({
 
       g.append('path')
         .attr('class', 'borders')
-        .attr('stroke', '#ff073a20')
+        .attr(
+          'stroke',
+          `${
+            mapOption === 'confirmed'
+              ? '#ff073a20'
+              : mapOption === 'active'
+              ? '#007bff20'
+              : mapOption === 'recovered'
+              ? '#28a74520'
+              : mapOption === 'deceased'
+              ? '#6c757d20'
+              : ''
+          }`
+        )
         .attr('fill', 'none')
         .attr('stroke-width', 2)
         .attr(
@@ -215,24 +228,27 @@ function ChoroplethMap({
     })();
   }, [mapMeta.geoDataFile, statistic, ready]);
 
-  const highlightRegionInMap = (name) => {
-    const paths = d3.selectAll('.path-region');
-    paths.classed('map-hover', (d, i, nodes) => {
-      const propertyField =
-        'district' in d.properties
-          ? propertyFieldMap['state']
-          : propertyFieldMap['country'];
-      if (name === d.properties[propertyField]) {
-        nodes[i].parentNode.appendChild(nodes[i]);
-        return true;
-      }
-      return false;
-    });
-  };
+  const highlightRegionInMap = useCallback(
+    (name) => {
+      const paths = d3.selectAll('.path-region');
+      paths.classed(`map-hover ${mapOption}`, (d, i, nodes) => {
+        const propertyField =
+          'district' in d.properties
+            ? propertyFieldMap['state']
+            : propertyFieldMap['country'];
+        if (name === d.properties[propertyField]) {
+          nodes[i].parentNode.appendChild(nodes[i]);
+          return true;
+        }
+        return false;
+      });
+    },
+    [mapOption]
+  );
 
   useEffect(() => {
     highlightRegionInMap(selectedRegion);
-  }, [svgRenderCount, selectedRegion]);
+  }, [svgRenderCount, selectedRegion, highlightRegionInMap]);
 
   return (
     <div>

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -117,7 +117,7 @@ function ChoroplethMap({
         .selectAll('path')
         .data(topology.features)
         .join('path')
-        .attr('class', 'path-region')
+        .attr('class', `path-region ${mapOption}`)
         .attr('fill', function (d) {
           const region = d.properties[propertyField];
           const n = mapData[region] ? mapData[region][mapOption] : 0;
@@ -228,10 +228,10 @@ function ChoroplethMap({
     })();
   }, [mapMeta.geoDataFile, statistic, ready]);
 
-  const highlightRegionInMap = useCallback(
-    (name) => {
+  useEffect(() => {
+    const highlightRegionInMap = (name) => {
       const paths = d3.selectAll('.path-region');
-      paths.classed(`map-hover ${mapOption}`, (d, i, nodes) => {
+      paths.classed('map-hover', (d, i, nodes) => {
         const propertyField =
           'district' in d.properties
             ? propertyFieldMap['state']
@@ -242,13 +242,9 @@ function ChoroplethMap({
         }
         return false;
       });
-    },
-    [mapOption]
-  );
-
-  useEffect(() => {
+    };
     highlightRegionInMap(selectedRegion);
-  }, [svgRenderCount, selectedRegion, highlightRegionInMap]);
+  }, [svgRenderCount, selectedRegion]);
 
   return (
     <div>

--- a/src/components/deltabargraph.js
+++ b/src/components/deltabargraph.js
@@ -109,7 +109,9 @@ function DeltaBarGraph({timeseries, arrayKey}) {
   );
 }
 
-export default React.memo(DeltaBarGraph);
+export default React.memo(DeltaBarGraph, () => {
+  return true;
+});
 
 function roundedBar(x, y, w, h, r, f) {
   if (!h) return;

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -45,7 +45,7 @@ function MapExplorer({
   const [testObj, setTestObj] = useState({});
   const [currentMap, setCurrentMap] = useState(mapMeta);
 
-  const [mapOption, setMapOption] = useState('recovered');
+  const [mapOption, setMapOption] = useState('confirmed');
 
   const [statistic, currentMapData] = useMemo(() => {
     const dataTypes = ['confirmed', 'active', 'recovered', 'deceased'];
@@ -296,7 +296,9 @@ function MapExplorer({
       </div>
 
       <div className="meta fadeInUp" style={{animationDelay: '2.4s'}}>
-        <h2>{name}</h2>
+        <h2 className={`${mapOption !== 'confirmed' ? mapOption : ''}`}>
+          {name}
+        </h2>
         {lastupdatedtime && (
           <div
             className={`last-update ${
@@ -325,7 +327,9 @@ function MapExplorer({
 
         {currentMap.mapType === MAP_TYPES.STATE &&
         currentHoveredRegion.name !== currentMap.name ? (
-          <h1 className="district-confirmed">
+          <h1
+            className={`district ${mapOption !== 'confirmed' ? mapOption : ''}`}
+          >
             {currentMapData[currentHoveredRegion.name]
               ? currentMapData[currentHoveredRegion.name][mapOption]
               : 0}

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -48,7 +48,7 @@ function MapExplorer({
   const [mapOption, setMapOption] = useState('confirmed');
 
   const [statistic, currentMapData] = useMemo(() => {
-    const dataTypes = ['confirmed', 'active', 'recovered', 'deaths'];
+    const dataTypes = ['confirmed', 'active', 'recovered', 'deceased'];
     const statistic = dataTypes.reduce((acc, dtype) => {
       acc[dtype] = {total: 0, max: 0};
       return acc;
@@ -62,7 +62,9 @@ function MapExplorer({
         }
         acc[state.state] = {};
         dataTypes.forEach((dtype) => {
-          const typeCount = parseInt(state[dtype]);
+          const typeCount = parseInt(
+            state[dtype !== 'deceased' ? dtype : 'deaths']
+          );
           statistic[dtype].total += typeCount;
           if (typeCount > statistic[dtype].max) {
             statistic[dtype].max = typeCount;
@@ -215,9 +217,7 @@ function MapExplorer({
           <h5>{window.innerWidth <= 769 ? 'Cnfmd' : 'Confirmed'}</h5>
           <div
             className="stats-bottom"
-            onClick={() => {
-              setMapOption('confirmed');
-            }}
+            onClick={() => setMapOption('confirmed')}
           >
             <h1>{formatNumber(panelRegion.confirmed)}</h1>
             <h6>{`+${formatNumber(panelRegion.deltaconfirmed)}`}</h6>
@@ -229,12 +229,7 @@ function MapExplorer({
           style={{animationDelay: '2.1s'}}
         >
           <h5>{window.innerWidth <= 769 ? 'Actv' : 'Active'}</h5>
-          <div
-            className="stats-bottom"
-            onClick={() => {
-              setMapOption('active');
-            }}
-          >
+          <div className="stats-bottom" onClick={() => setMapOption('active')}>
             <h1>{formatNumber(panelRegion.active)}</h1>
             <h6>{` `}</h6>
           </div>
@@ -247,9 +242,7 @@ function MapExplorer({
           <h5>{window.innerWidth <= 769 ? 'Rcvrd' : 'Recovered'}</h5>
           <div
             className="stats-bottom"
-            onClick={() => {
-              setMapOption('recovered');
-            }}
+            onClick={() => setMapOption('recovered')}
           >
             <h1>{formatNumber(panelRegion.recovered)}</h1>
             <h6>{`+${formatNumber(panelRegion.deltarecovered)}`}</h6>
@@ -263,9 +256,7 @@ function MapExplorer({
           <h5>{window.innerWidth <= 769 ? 'Dcsd' : 'Deceased'}</h5>
           <div
             className="stats-bottom"
-            onClick={() => {
-              setMapOption('deaths');
-            }}
+            onClick={() => setMapOption('deceased')}
           >
             <h1>{formatNumber(panelRegion.deaths)}</h1>
             <h6>{`+${formatNumber(panelRegion.deltadeaths)}`}</h6>
@@ -330,11 +321,11 @@ function MapExplorer({
         currentHoveredRegion.name !== currentMap.name ? (
           <h1 className="district-confirmed">
             {currentMapData[currentHoveredRegion.name]
-              ? currentMapData[currentHoveredRegion.name]
+              ? currentMapData[currentHoveredRegion.name][mapOption]
               : 0}
             <br />
             <span style={{fontSize: '0.75rem', fontWeight: 600}}>
-              confirmed
+              {mapOption}
             </span>
           </h1>
         ) : null}

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -45,8 +45,14 @@ function MapExplorer({
   const [testObj, setTestObj] = useState({});
   const [currentMap, setCurrentMap] = useState(mapMeta);
 
+  const [mapOption, setMapOption] = useState('confirmed');
+
   const [statistic, currentMapData] = useMemo(() => {
-    const statistic = {total: 0, maxConfirmed: 0};
+    const dataTypes = ['confirmed', 'active', 'recovered', 'deaths'];
+    const statistic = dataTypes.reduce((acc, dtype) => {
+      acc[dtype] = {total: 0, max: 0};
+      return acc;
+    }, {});
     let currentMapData = {};
 
     if (currentMap.mapType === MAP_TYPES.COUNTRY) {
@@ -54,13 +60,15 @@ function MapExplorer({
         if (state.state === 'Total') {
           return acc;
         }
-        const confirmed = parseInt(state.confirmed);
-        statistic.total += confirmed;
-        if (confirmed > statistic.maxConfirmed) {
-          statistic.maxConfirmed = confirmed;
-        }
-
-        acc[state.state] = state.confirmed;
+        acc[state.state] = {};
+        dataTypes.forEach((dtype) => {
+          const typeCount = parseInt(state[dtype]);
+          statistic[dtype].total += typeCount;
+          if (typeCount > statistic[dtype].max) {
+            statistic[dtype].max = typeCount;
+          }
+          acc[state.state][dtype] = typeCount;
+        });
         return acc;
       }, {});
     } else if (currentMap.mapType === MAP_TYPES.STATE) {
@@ -68,12 +76,15 @@ function MapExplorer({
         stateDistrictWiseData[currentMap.name] || {districtData: {}}
       ).districtData;
       currentMapData = Object.keys(districtWiseData).reduce((acc, district) => {
-        const confirmed = parseInt(districtWiseData[district].confirmed);
-        statistic.total += confirmed;
-        if (confirmed > statistic.maxConfirmed) {
-          statistic.maxConfirmed = confirmed;
-        }
-        acc[district] = districtWiseData[district].confirmed;
+        acc[district] = {};
+        dataTypes.forEach((dtype) => {
+          const typeCount = parseInt(districtWiseData[district][dtype]);
+          statistic[dtype].total += typeCount;
+          if (typeCount > statistic[dtype].max) {
+            statistic[dtype].max = typeCount;
+          }
+          acc[district][dtype] = typeCount;
+        });
         return acc;
       }, {});
     }
@@ -98,8 +109,8 @@ function MapExplorer({
           districtData = {
             confirmed: 0,
             active: 0,
-            deaths: 0,
             recovered: 0,
+            deaths: 0,
           };
         }
         const currentHoveredRegion = getRegionFromDistrict(districtData, name);
@@ -202,7 +213,12 @@ function MapExplorer({
       <div className="map-stats">
         <div className="stats fadeInUp" style={{animationDelay: '2s'}}>
           <h5>{window.innerWidth <= 769 ? 'Cnfmd' : 'Confirmed'}</h5>
-          <div className="stats-bottom">
+          <div
+            className="stats-bottom"
+            onClick={() => {
+              setMapOption('confirmed');
+            }}
+          >
             <h1>{formatNumber(panelRegion.confirmed)}</h1>
             <h6>{`+${formatNumber(panelRegion.deltaconfirmed)}`}</h6>
           </div>
@@ -213,7 +229,12 @@ function MapExplorer({
           style={{animationDelay: '2.1s'}}
         >
           <h5>{window.innerWidth <= 769 ? 'Actv' : 'Active'}</h5>
-          <div className="stats-bottom">
+          <div
+            className="stats-bottom"
+            onClick={() => {
+              setMapOption('active');
+            }}
+          >
             <h1>{formatNumber(panelRegion.active)}</h1>
             <h6>{` `}</h6>
           </div>
@@ -224,7 +245,12 @@ function MapExplorer({
           style={{animationDelay: '2.2s'}}
         >
           <h5>{window.innerWidth <= 769 ? 'Rcvrd' : 'Recovered'}</h5>
-          <div className="stats-bottom">
+          <div
+            className="stats-bottom"
+            onClick={() => {
+              setMapOption('recovered');
+            }}
+          >
             <h1>{formatNumber(panelRegion.recovered)}</h1>
             <h6>{`+${formatNumber(panelRegion.deltarecovered)}`}</h6>
           </div>
@@ -235,7 +261,12 @@ function MapExplorer({
           style={{animationDelay: '2.3s'}}
         >
           <h5>{window.innerWidth <= 769 ? 'Dcsd' : 'Deceased'}</h5>
-          <div className="stats-bottom">
+          <div
+            className="stats-bottom"
+            onClick={() => {
+              setMapOption('deceased');
+            }}
+          >
             <h1>{formatNumber(panelRegion.deaths)}</h1>
             <h6>{`+${formatNumber(panelRegion.deltadeaths)}`}</h6>
           </div>
@@ -343,6 +374,7 @@ function MapExplorer({
         selectedRegion={selectedRegion}
         setSelectedRegion={setSelectedRegion}
         isCountryLoaded={isCountryLoaded}
+        mapOption={mapOption}
       />
     </div>
   );

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -36,6 +36,7 @@ function MapExplorer({
   isCountryLoaded,
   anchor,
   setAnchor,
+  mapOptionProp,
 }) {
   const [selectedRegion, setSelectedRegion] = useState({});
   const [panelRegion, setPanelRegion] = useState(getRegionFromState(states[0]));
@@ -127,6 +128,10 @@ function MapExplorer({
     },
     [states, stateDistrictWiseData, onMapHighlightChange]
   );
+
+  useEffect(() => {
+    if (mapOptionProp) setMapOption(mapOptionProp);
+  }, [mapOptionProp]);
 
   useEffect(() => {
     if (regionHighlighted === undefined || regionHighlighted === null) return;

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -264,7 +264,7 @@ function MapExplorer({
           <div
             className="stats-bottom"
             onClick={() => {
-              setMapOption('deceased');
+              setMapOption('deaths');
             }}
           >
             <h1>{formatNumber(panelRegion.deaths)}</h1>

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -130,6 +130,10 @@ function MapExplorer({
   );
 
   useEffect(() => {
+    if (mapOptionProp) setMapOption(mapOptionProp);
+  }, [mapOptionProp, setMapOption]);
+
+  useEffect(() => {
     if (regionHighlighted === undefined || regionHighlighted === null) return;
 
     const isState = !('district' in regionHighlighted);
@@ -161,7 +165,9 @@ function MapExplorer({
       if (newMap.mapType === MAP_TYPES.COUNTRY) {
         setHoveredRegion(states[0].state, newMap);
       } else if (newMap.mapType === MAP_TYPES.STATE) {
-        const {districtData} = stateDistrictWiseData[name] || {};
+        const {districtData} = stateDistrictWiseData[name] || {
+          districtData: {},
+        };
         const topDistrict = Object.keys(districtData)
           .filter((name) => name !== 'Unknown')
           .sort((a, b) => {
@@ -378,7 +384,7 @@ function MapExplorer({
           selectedRegion={selectedRegion}
           setSelectedRegion={setSelectedRegion}
           isCountryLoaded={isCountryLoaded}
-          mapOption={mapOptionProp || mapOption}
+          mapOption={mapOption}
         />
       )}
     </div>

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -341,9 +341,10 @@ function MapExplorer({
         ) : null}
 
         {currentMap.mapType === MAP_TYPES.STATE &&
-        currentMapData.Unknown > 0 ? (
+        currentMapData.Unknown &&
+        currentMapData.Unknown[mapOption] > 0 ? (
           <h4 className="unknown">
-            Districts unknown for {currentMapData.Unknown} people
+            Districts unknown for {currentMapData.Unknown[mapOption]} people
           </h4>
         ) : null}
 

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -45,7 +45,7 @@ function MapExplorer({
   const [testObj, setTestObj] = useState({});
   const [currentMap, setCurrentMap] = useState(mapMeta);
 
-  const [mapOption, setMapOption] = useState('confirmed');
+  const [mapOption, setMapOption] = useState('recovered');
 
   const [statistic, currentMapData] = useMemo(() => {
     const dataTypes = ['confirmed', 'active', 'recovered', 'deceased'];
@@ -213,51 +213,57 @@ function MapExplorer({
       </div>
 
       <div className="map-stats">
-        <div className="stats fadeInUp" style={{animationDelay: '2s'}}>
+        <div
+          className={`stats fadeInUp ${
+            mapOption === 'confirmed' ? 'focused' : ''
+          }`}
+          style={{animationDelay: '2s'}}
+          onClick={() => setMapOption('confirmed')}
+        >
           <h5>{window.innerWidth <= 769 ? 'Cnfmd' : 'Confirmed'}</h5>
-          <div
-            className="stats-bottom"
-            onClick={() => setMapOption('confirmed')}
-          >
+          <div className="stats-bottom">
             <h1>{formatNumber(panelRegion.confirmed)}</h1>
             <h6>{`+${formatNumber(panelRegion.deltaconfirmed)}`}</h6>
           </div>
         </div>
 
         <div
-          className="stats is-blue fadeInUp"
+          className={`stats is-blue fadeInUp ${
+            mapOption === 'active' ? 'focused' : ''
+          }`}
           style={{animationDelay: '2.1s'}}
+          onClick={() => setMapOption('active')}
         >
           <h5>{window.innerWidth <= 769 ? 'Actv' : 'Active'}</h5>
-          <div className="stats-bottom" onClick={() => setMapOption('active')}>
+          <div className="stats-bottom">
             <h1>{formatNumber(panelRegion.active)}</h1>
             <h6>{` `}</h6>
           </div>
         </div>
 
         <div
-          className="stats is-green fadeInUp"
+          className={`stats is-green fadeInUp ${
+            mapOption === 'recovered' ? 'focused' : ''
+          }`}
           style={{animationDelay: '2.2s'}}
+          onClick={() => setMapOption('recovered')}
         >
           <h5>{window.innerWidth <= 769 ? 'Rcvrd' : 'Recovered'}</h5>
-          <div
-            className="stats-bottom"
-            onClick={() => setMapOption('recovered')}
-          >
+          <div className="stats-bottom">
             <h1>{formatNumber(panelRegion.recovered)}</h1>
             <h6>{`+${formatNumber(panelRegion.deltarecovered)}`}</h6>
           </div>
         </div>
 
         <div
-          className="stats is-gray fadeInUp"
+          className={`stats is-gray fadeInUp ${
+            mapOption === 'deceased' ? 'focused' : ''
+          }`}
           style={{animationDelay: '2.3s'}}
+          onClick={() => setMapOption('deceased')}
         >
           <h5>{window.innerWidth <= 769 ? 'Dcsd' : 'Deceased'}</h5>
-          <div
-            className="stats-bottom"
-            onClick={() => setMapOption('deceased')}
-          >
+          <div className="stats-bottom">
             <h1>{formatNumber(panelRegion.deaths)}</h1>
             <h6>{`+${formatNumber(panelRegion.deltadeaths)}`}</h6>
           </div>

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -11,6 +11,7 @@ import {formatDistance, format, parse} from 'date-fns';
 import React, {useState, useEffect, useMemo, useCallback} from 'react';
 import * as Icon from 'react-feather';
 import {Link} from 'react-router-dom';
+import {useLocalStorage} from 'react-use';
 
 const getRegionFromState = (state) => {
   if (!state) return;
@@ -45,8 +46,7 @@ function MapExplorer({
   );
   const [testObj, setTestObj] = useState({});
   const [currentMap, setCurrentMap] = useState(mapMeta);
-
-  const [mapOption, setMapOption] = useState('confirmed');
+  const [mapOption, setMapOption] = useLocalStorage('mapOption', 'active');
 
   const [statistic, currentMapData] = useMemo(() => {
     const dataTypes = ['confirmed', 'active', 'recovered', 'deceased'];
@@ -128,10 +128,6 @@ function MapExplorer({
     },
     [states, stateDistrictWiseData, onMapHighlightChange]
   );
-
-  useEffect(() => {
-    if (mapOptionProp) setMapOption(mapOptionProp);
-  }, [mapOptionProp]);
 
   useEffect(() => {
     if (regionHighlighted === undefined || regionHighlighted === null) return;
@@ -372,17 +368,19 @@ function MapExplorer({
         ) : null}
       </div>
 
-      <ChoroplethMap
-        statistic={statistic}
-        mapMeta={currentMap}
-        mapData={currentMapData}
-        setHoveredRegion={setHoveredRegion}
-        changeMap={switchMapToState}
-        selectedRegion={selectedRegion}
-        setSelectedRegion={setSelectedRegion}
-        isCountryLoaded={isCountryLoaded}
-        mapOption={mapOption}
-      />
+      {mapOption && (
+        <ChoroplethMap
+          statistic={statistic}
+          mapMeta={currentMap}
+          mapData={currentMapData}
+          setHoveredRegion={setHoveredRegion}
+          changeMap={switchMapToState}
+          selectedRegion={selectedRegion}
+          setSelectedRegion={setSelectedRegion}
+          isCountryLoaded={isCountryLoaded}
+          mapOption={mapOptionProp || mapOption}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/minigraph.js
+++ b/src/components/minigraph.js
@@ -15,7 +15,7 @@ function Minigraph({timeseries}) {
   const graphData = useCallback((data) => {
     if (data.length <= 1) return 0;
 
-    const margin = {top: 0, right: 10, bottom: 30, left: 0};
+    const margin = {top: 10, right: 5, bottom: 20, left: 5};
     const chartRight = 100 - margin.right;
     const chartBottom = 100 - margin.bottom;
 
@@ -62,7 +62,7 @@ function Minigraph({timeseries}) {
         .datum(data)
         .attr('fill', 'none')
         .attr('stroke', color + '99')
-        .attr('stroke-width', 3)
+        .attr('stroke-width', 2.5)
         .attr('cursor', 'pointer')
         .attr(
           'd',
@@ -117,8 +117,8 @@ function Minigraph({timeseries}) {
         <svg
           ref={svgRef1}
           width="100"
-          height="100"
-          viewBox="0 0 100 100"
+          height="75"
+          viewBox="0 0 100 75"
           preserveAspectRatio="xMidYMid meet"
         />
       </div>
@@ -130,8 +130,8 @@ function Minigraph({timeseries}) {
         <svg
           ref={svgRef2}
           width="100"
-          height="100"
-          viewBox="0 0 100 100"
+          height="75"
+          viewBox="0 0 100 75"
           preserveAspectRatio="xMidYMid meet"
         />
       </div>
@@ -143,8 +143,8 @@ function Minigraph({timeseries}) {
         <svg
           ref={svgRef3}
           width="100"
-          height="100"
-          viewBox="0 0 100 100"
+          height="75"
+          viewBox="0 0 100 75"
           preserveAspectRatio="xMidYMid meet"
         />
       </div>
@@ -156,8 +156,8 @@ function Minigraph({timeseries}) {
         <svg
           ref={svgRef4}
           width="100"
-          height="100"
-          viewBox="0 0 100 100"
+          height="75"
+          viewBox="0 0 100 75"
           preserveAspectRatio="xMidYMid meet"
         />
       </div>

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -198,7 +198,7 @@ function State(props) {
                   stateDistrictWiseData={districtData}
                   stateTestData={testData}
                   isCountryLoaded={false}
-                  mapOption={mapOption}
+                  mapOptionProp={mapOption}
                 />
               }
             </React.Fragment>

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -16,10 +16,10 @@ import {
 import anime from 'animejs';
 import axios from 'axios';
 import {format, parse} from 'date-fns';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useRef, useState} from 'react';
 import * as Icon from 'react-feather';
 import {Link, useParams} from 'react-router-dom';
-import {useMeasure} from 'react-use';
+import {useMeasure, useEffectOnce} from 'react-use';
 
 function State(props) {
   const mapRef = useRef();
@@ -40,11 +40,9 @@ function State(props) {
   const [mapOption, setMapOption] = useState('confirmed');
   const [mapSwitcher, {width}] = useMeasure();
 
-  useEffect(() => {
-    if (fetched === false) {
-      getState(stateCode);
-    }
-  }, [fetched, stateCode]);
+  useEffectOnce(() => {
+    getState(stateCode);
+  });
 
   const getState = async (code) => {
     try {
@@ -78,6 +76,23 @@ function State(props) {
       const sourceList = sourcesResponse.sources_list;
       setSources(sourceList.filter((state) => state.statecode === code));
       setFetched(true);
+      anime({
+        targets: '.highlight',
+        duration: 200,
+        delay: 3000,
+        translateX:
+          mapOption === 'confirmed'
+            ? `${width * 0}px`
+            : mapOption === 'active'
+            ? `${width * 0.25}px`
+            : mapOption === 'recovered'
+            ? `${width * 0.5}px`
+            : mapOption === 'deceased'
+            ? `${width * 0.75}px`
+            : '0px',
+        easing: 'spring(1, 80, 90, 10)',
+        opacity: 1,
+      });
     } catch (err) {
       console.log(err);
     }
@@ -137,7 +152,10 @@ function State(props) {
             <div className="map-switcher" ref={mapSwitcher}>
               <div
                 className={`highlight ${mapOption}`}
-                style={{transform: `translateX(${width * -0.01}px)`}}
+                style={{
+                  transform: `translateX(${width * 0}px)`,
+                  opacity: 0,
+                }}
               ></div>
               <div
                 className="clickable"
@@ -145,7 +163,7 @@ function State(props) {
                   setMapOption('confirmed');
                   anime({
                     targets: '.highlight',
-                    translateX: `${width * -0.01}px`,
+                    translateX: `${width * 0}px`,
                     easing: 'spring(1, 80, 90, 10)',
                   });
                 }}
@@ -156,7 +174,7 @@ function State(props) {
                   setMapOption('active');
                   anime({
                     targets: '.highlight',
-                    translateX: `${width * 0.23}px`,
+                    translateX: `${width * 0.25}px`,
                     easing: 'spring(1, 80, 90, 10)',
                   });
                 }}
@@ -167,7 +185,7 @@ function State(props) {
                   setMapOption('recovered');
                   anime({
                     targets: '.highlight',
-                    translateX: `${width * 0.47}px`,
+                    translateX: `${width * 0.5}px`,
                     easing: 'spring(1, 80, 90, 10)',
                   });
                 }}
@@ -178,7 +196,7 @@ function State(props) {
                   setMapOption('deceased');
                   anime({
                     targets: '.highlight',
-                    translateX: `${width * 0.73}px`,
+                    translateX: `${width * 0.75}px`,
                     easing: 'spring(1, 80, 90, 10)',
                   });
                 }}
@@ -220,11 +238,11 @@ function State(props) {
                 <div className="sources-right">
                   Data collected from sources{' '}
                   {sources.length > 0
-                    ? Object.keys(sources[0]).map((key) => {
+                    ? Object.keys(sources[0]).map((key, index) => {
                         if (key.match('source') && sources[0][key] !== '') {
                           const num = key.match(/\d+/);
                           return (
-                            <React.Fragment>
+                            <React.Fragment key={index}>
                               {num > 1 ? ',' : ''}
                               <a href={sources[0][key]}>{num}</a>
                             </React.Fragment>

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -13,11 +13,13 @@ import {
   parseStateTimeseries,
 } from '../utils/commonfunctions';
 
+import anime from 'animejs';
 import axios from 'axios';
 import {format, parse} from 'date-fns';
 import React, {useEffect, useRef, useState} from 'react';
 import * as Icon from 'react-feather';
 import {Link, useParams} from 'react-router-dom';
+import {useMeasure} from 'react-use';
 
 function State(props) {
   const mapRef = useRef();
@@ -35,6 +37,8 @@ function State(props) {
   const [sources, setSources] = useState({});
   const [districtData, setDistrictData] = useState({});
   const [stateName] = useState(STATE_CODES[stateCode]);
+  const [mapOption, setMapOption] = useState('confirmed');
+  const [mapSwitcher, {width}] = useMeasure();
 
   useEffect(() => {
     if (fetched === false) {
@@ -129,6 +133,59 @@ function State(props) {
             </div>
           </div>
 
+          {fetched && (
+            <div className="map-switcher" ref={mapSwitcher}>
+              <div
+                className={`highlight ${mapOption}`}
+                style={{transform: `translateX(${width * -0.01}px)`}}
+              ></div>
+              <div
+                className="clickable"
+                onClick={() => {
+                  setMapOption('confirmed');
+                  anime({
+                    targets: '.highlight',
+                    translateX: `${width * -0.01}px`,
+                    easing: 'spring(1, 80, 90, 10)',
+                  });
+                }}
+              ></div>
+              <div
+                className="clickable"
+                onClick={() => {
+                  setMapOption('active');
+                  anime({
+                    targets: '.highlight',
+                    translateX: `${width * 0.23}px`,
+                    easing: 'spring(1, 80, 90, 10)',
+                  });
+                }}
+              ></div>
+              <div
+                className="clickable"
+                onClick={() => {
+                  setMapOption('recovered');
+                  anime({
+                    targets: '.highlight',
+                    translateX: `${width * 0.47}px`,
+                    easing: 'spring(1, 80, 90, 10)',
+                  });
+                }}
+              ></div>
+              <div
+                className="clickable"
+                onClick={() => {
+                  setMapOption('deceased');
+                  anime({
+                    targets: '.highlight',
+                    translateX: `${width * 0.73}px`,
+                    easing: 'spring(1, 80, 90, 10)',
+                  });
+                }}
+              ></div>
+            </div>
+          )}
+
           {fetched && <Level data={stateData} />}
           {fetched && <Minigraph timeseries={timeseries} />}
           {fetched && (
@@ -141,6 +198,7 @@ function State(props) {
                   stateDistrictWiseData={districtData}
                   stateTestData={testData}
                   isCountryLoaded={false}
+                  mapOption={mapOption}
                 />
               }
             </React.Fragment>


### PR DESCRIPTION
**Description of PR**
Refactored code to plot maps based on active, recovered and deceased counts. Map types are switched by clicking on the respective panels above the map. The colours represent absolute values and are not normalized in any way (population, total cases etc.).

**Type of PR**

- [ ] Bugfix
- [x] New feature

**Relevant Issues**  
Fixes #1388
Addresses #675

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Peek 2020-04-23 17-25](https://user-images.githubusercontent.com/27727946/80096663-8bc14600-8587-11ea-80f5-e101bb18d328.gif)

