### PR TITLE
Fix: Close expanded navbar on clicking logo.

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -24,7 +24,12 @@ function Navbar({pages, darkMode, setDarkMode}) {
         {darkMode ? <Icon.Sun color={'#ffc107'} /> : <Icon.Moon />}
       </div>
       <div className="navbar-middle">
-        <Link to="/">
+        <Link
+          to="/"
+          onClick={() => {
+            setExpand(false);
+          }}
+        >
           Covid19<span>India</span>
         </Link>
       </div>


### PR DESCRIPTION
**Description of PR**
* fixed not closing  of expanded navbar on click of covid19India in mobile and desktop

**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes #1413 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![fix](https://user-images.githubusercontent.com/45959932/80015406-4e10de80-84ef-11ea-8b42-a525f8961f9e.gif)
