### PR TITLE
Style: Use different dark-mode color for desktop navbar.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -3973,6 +3973,16 @@ body.modal-open {
   .PatientsDB {
     margin-left: 5rem;
   }
+
+  .dark-mode {
+    .Navbar, .expand {
+      background: #1e1e30 !important;
+    }
+
+    .navbar-right {
+      background: #1e1e30 !important;
+    }
+  }
 }
 
 @media (max-width: 769px) {
@@ -4462,16 +4472,27 @@ body.modal-open {
     background: #161625 !important;
   }
 
+  .expand {
+    background: #1e1e30 !important;
+  }
+
   .Navbar, .expand {
-    background: #161625 !important;
+    border-right: 0;
+
     .navbar-middle {
       color: #bdbdbd;
     }
 
     .navbar-right {
-      background: #161625 !important;
+      background: #1e1e30 !important;
+      & > span {
+        display: none;
+      }
+
+      & > span:first-child {
+        display: initial;
+      }
     }
-    border-right: 0;
   }
 
   table {


### PR DESCRIPTION
**Description of PR**
SideNav(Desktop)/TopNav(Mobile) Color is darker than the background in light mode which is good. When I switch to dark mode complete page color get chaged to one color but the SideNav(Desktop)/TopNav(Mobile) color should be little dark.

**Type of PR**

- [Yes] Bugfix
- [No] New feature

**Relevant Issues**  
Fixes #1416

**Checklist**

- [Yes ] Compiles and passes lint tests
- [Yes] Properly formatted
- [Yes] Tested on desktop
- [Yes] Tested on phone

| Label             |  Image |
:-------------------------:|:-------------------------:
| Expected | <img width="1075" alt="updated-behviour" src="https://user-images.githubusercontent.com/15886737/80017890-e492cf00-84f2-11ea-8b6c-4b709f5fd21f.png"> | 
| Current Behaviour |<img width="1075" alt="default-behavious" src="https://user-images.githubusercontent.com/15886737/80017865-d80e7680-84f2-11ea-935d-e41a2bd7a9c9.png"> |