### PR TITLE
Style: Support dark mode for Essentials search input.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4667,6 +4667,10 @@ body.modal-open {
       }
     }
 
+    input.MuiInputBase-input{
+      color: $dark-m-white;
+    }
+
 	.searchbar {
 		.MuiFormLabel-root {
 			color: rgba(232, 230, 227, 0.54);


### PR DESCRIPTION
**Description of PR**
* color inside search input in dark mode is not visible

**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes #1419 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Screenshot from 2020-04-23 00-03-39](https://user-images.githubusercontent.com/45959932/80021876-d5af1b00-84f8-11ea-88b0-555ecae7e441.png)
