### PR TITLE
Style: Expand charts to fit container in DeepDive.

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4088,6 +4088,7 @@ body.modal-open {
       .card {
         margin-bottom: 0;
         height: 25rem;
+        flex: 0 1 100%;
       }
 
       .chart-title {


### PR DESCRIPTION
**Description of PR**
* fixed deep dive charts are not aligned properly in mobile devices.

**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes #1422 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Screenshot from 2020-04-23 02-07-40](https://user-images.githubusercontent.com/45959932/80032610-0e56f080-8509-11ea-9488-ac82c93c1cf0.png)
![Screenshot from 2020-04-23 02-21-03](https://user-images.githubusercontent.com/45959932/80032654-1e6ed000-8509-11ea-8526-399d9d2c4b77.png)
