### PR TITLE
Improv: Add legends for daily confirmed chart in DeepDive

### DIFF
--- a/src/components/Charts/dailyconfirmedchart.js
+++ b/src/components/Charts/dailyconfirmedchart.js
@@ -8,7 +8,7 @@ import {
 import deepmerge from 'deepmerge';
 import moment from 'moment';
 import React from 'react';
-import {Bar} from 'react-chartjs-2';
+import {Bar, defaults} from 'react-chartjs-2';
 
 function DailyConfirmedChart(props) {
   const dates = [];
@@ -44,7 +44,7 @@ function DailyConfirmedChart(props) {
       },
       {
         data: confirmed,
-        label: 'confirmed',
+        label: 'Confirmed',
         backgroundColor: '#ff6862',
       },
     ],
@@ -55,7 +55,18 @@ function DailyConfirmedChart(props) {
       mode: 'index',
     },
     legend: {
-      display: false,
+      display: true,
+      reverse: true,
+      labels: {
+        usePointStyle: true, // Required to change pointstyle to 'rectRounded' from 'circle'
+        generateLabels: (chart) => {
+          const labels = defaults.global.legend.labels.generateLabels(chart);
+          labels.forEach((label) => {
+            label.pointStyle = 'rectRounded';
+          });
+          return labels;
+        },
+      },
     },
     scales: {
       xAxes: [


### PR DESCRIPTION
**Description of PR**
Added legends for daily confirmed chart as requested

**Type of PR**
- [x] Enhancement

**Relevant Issues**  
Fixes #866 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

![Screen Shot 2020-04-23 at 2 26 11 AM](https://user-images.githubusercontent.com/6641694/80033145-dac89600-8509-11ea-823e-2fdb39840ade.png)
Please note the inconsistency in order of total cases and daily cases charts. Let me know if change is required and how to change.