### PR TITLE
Fixed number of active cases

### DIFF
--- a/src/utils/commonfunctions.js
+++ b/src/utils/commonfunctions.js
@@ -66,10 +66,14 @@ export const preprocessTimeseries = (timeseries) => {
     dailyrecovered: +stat.dailyrecovered,
     dailydeceased: +stat.dailydeceased,
     // Active = Confimed - Recovered - Deceased
-    totalactive:
-      +stat.totalconfirmed - +stat.totalrecovered - +stat.totaldeceased,
-    dailyactive:
-      +stat.dailyconfirmed - +stat.dailyrecovered - +stat.dailydeceased,
+    totalactive: Math.max(
+      0,
+      +stat.totalconfirmed - +stat.totalrecovered - +stat.totaldeceased
+    ),
+    dailyactive: Math.max(
+      0,
+      +stat.dailyconfirmed - +stat.dailyrecovered - +stat.dailydeceased
+    ),
   }));
 };
 
@@ -122,8 +126,14 @@ export const parseStateTimeseries = ({states_daily: data}) => {
           totalrecovered: totalrecovered,
           totaldeceased: totaldeceased,
           // Active = Confimed - Recovered - Deceased
-          totalactive: totalconfirmed - totalrecovered - totaldeceased,
-          dailyactive: dailyconfirmed - dailyrecovered - dailydeceased,
+          totalactive: Math.max(
+            0,
+            totalconfirmed - totalrecovered - totaldeceased
+          ),
+          dailyactive: Math.max(
+            0,
+            dailyconfirmed - dailyrecovered - dailydeceased
+          ),
         });
       });
     }


### PR DESCRIPTION
**Description of PR**

There was problem with the number of active cases. The formula to calculate the number of active cases is as follows:

> Active = Confimed - Recovered - Deceased

The problem with this is that if for any day the number of recovered + number of deceased is more than number of confimed then the number of active cases will be negative for any day, but this is logically wrong (_how can a number of active cases be negative for a day?_). The formula is updated to:

> Active = Max(0, Confimed - Recovered - Deceased)

This will also fix the problem with the time series 'Daily' graphs. This formula is also added for the total active cases. There might be a situation when this can also be negative.

**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes Number of daily active cases.

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Before:
![Selection_037](https://user-images.githubusercontent.com/8968547/80034548-398f0f00-850c-11ea-9c73-0858086edad9.png)

After:
![Selection_033](https://user-images.githubusercontent.com/8968547/80034503-28460280-850c-11ea-9690-a64153e12521.png)
