### PR TITLE
Fix: Rendering unnecessary district table rows

### DIFF
--- a/src/__tests__/components/Row.test.js
+++ b/src/__tests__/components/Row.test.js
@@ -1,7 +1,8 @@
 import Row from '../../components/row';
 
-import {shallow} from 'enzyme';
+import {mount} from 'enzyme';
 import React from 'react';
+import {MemoryRouter} from 'react-router-dom';
 
 const state = {
   active: '1',
@@ -27,8 +28,25 @@ const districts = {
 };
 
 describe('Row component', () => {
-  let wrapper;
   const RealDate = Date;
+  const handleReveal = jest.fn();
+
+  const wrapper = mount(
+    <MemoryRouter>
+      <table>
+        <tbody>
+          <Row
+            state={state}
+            districts={districts}
+            index={1}
+            total={false}
+            reveal={true}
+            handleReveal={handleReveal}
+          />
+        </tbody>
+      </table>
+    </MemoryRouter>
+  );
 
   beforeAll(() => {
     const mockedDate = new Date('2020-04-13T17:11:38.158Z');
@@ -38,10 +56,6 @@ describe('Row component', () => {
         return mockedDate;
       }
     };
-
-    wrapper = shallow(
-      <Row state={state} districts={districts} index={1} total={false} />
-    );
   });
 
   afterAll(() => {
@@ -67,15 +81,19 @@ describe('Row component', () => {
     expect(deaths).toEqual('-');
   });
 
-  test('State last update data', () => {
+  test('Districts and the confirmed cases', () => {
+    const stateRow = wrapper.find('tr.state');
+    expect(stateRow).toHaveLength(1);
+
+    stateRow.simulate('click');
+    expect(handleReveal).toHaveBeenCalledWith('Andaman and Nicobar Islands');
+
+    const districtsSelector = wrapper.find('tr.district');
     const stateLastUpdate = wrapper.find('tr.state-last-update');
 
-    expect(stateLastUpdate.text()).toMatch(/14 days ago/i);
-  });
-
-  test('Districts and the confirmed cases', () => {
-    const districtsSelector = wrapper.find('tr.district');
     expect(districtsSelector).toHaveLength(3);
+    expect(stateLastUpdate.text()).toMatch(/14 days ago/i);
+
     districtsSelector.forEach((e, index) => {
       const cells = e.find('td');
       const district = cells.at(0).childAt(0).text();

--- a/src/components/row.js
+++ b/src/components/row.js
@@ -14,6 +14,7 @@ function Row(props) {
   const [state, setState] = useState(props.state);
   const [districts, setDistricts] = useState(props.districts);
   const [sortedDistricts, setSortedDistricts] = useState(props.districts);
+  const [showDistricts, setShowDistricts] = useState(false);
   const [sortData, setSortData] = useState({
     sortColumn: localStorage.getItem('district.sortColumn')
       ? localStorage.getItem('district.sortColumn')
@@ -53,6 +54,7 @@ function Row(props) {
 
   const handleReveal = () => {
     props.handleReveal(props.state.state);
+    setShowDistricts(!showDistricts);
   };
 
   const handleTooltip = (e) => {
@@ -125,9 +127,10 @@ function Row(props) {
           <div className="table__title-wrapper">
             <span
               className={`dropdown ${
-                props.reveal ? 'rotateRightDown' : 'rotateDownRight'
+                props.reveal && showDistricts
+                  ? 'rotateRightDown'
+                  : 'rotateDownRight'
               }`}
-              style={{display: !props.total ? '' : 'none'}}
               onClick={() => {
                 handleReveal();
               }}
@@ -193,89 +196,88 @@ function Row(props) {
         </td>
       </tr>
 
-      <tr
-        className={'state-last-update'}
-        style={{display: props.reveal && !props.total ? '' : 'none'}}
-      >
-        <td colSpan={2}>
-          <div className="last-update">
-            <h6>Last updated&nbsp;</h6>
-            <h6
-              title={
-                isNaN(Date.parse(formatDate(props.state.lastupdatedtime)))
-                  ? ''
-                  : formatDateAbsolute(props.state.lastupdatedtime)
-              }
-            >
-              {isNaN(Date.parse(formatDate(props.state.lastupdatedtime)))
-                ? ''
-                : `${formatDistance(
-                    new Date(formatDate(props.state.lastupdatedtime)),
-                    new Date()
-                  )} ago`}
-            </h6>
-          </div>
-        </td>
-      </tr>
+      {showDistricts && (
+        <React.Fragment>
+          <tr className={'state-last-update'}>
+            <td colSpan={2}>
+              <div className="last-update">
+                <h6>Last updated&nbsp;</h6>
+                <h6
+                  title={
+                    isNaN(Date.parse(formatDate(props.state.lastupdatedtime)))
+                      ? ''
+                      : formatDateAbsolute(props.state.lastupdatedtime)
+                  }
+                >
+                  {isNaN(Date.parse(formatDate(props.state.lastupdatedtime)))
+                    ? ''
+                    : `${formatDistance(
+                        new Date(formatDate(props.state.lastupdatedtime)),
+                        new Date()
+                      )} ago`}
+                </h6>
+              </div>
+            </td>
+          </tr>
 
-      <tr
-        className={`district-heading`}
-        style={{display: props.reveal && !props.total ? '' : 'none'}}
-      >
-        <td onClick={(e) => handleSort('district')}>
-          <div className="heading-content">
-            <abbr title="District">District</abbr>
-            <div
-              style={{
-                display:
-                  sortData.sortColumn === 'district' ? 'initial' : 'none',
-              }}
-            >
-              {sortData.isAscending ? (
-                <div className="arrow-up" />
-              ) : (
-                <div className="arrow-down" />
-              )}
-            </div>
-          </div>
-        </td>
-        <td onClick={(e) => handleSort('confirmed')}>
-          <div className="heading-content">
-            <abbr
-              className={`${window.innerWidth <= 769 ? 'is-cherry' : ''}`}
-              title="Confirmed"
-            >
-              {window.innerWidth <= 769
-                ? window.innerWidth <= 375
-                  ? 'C'
-                  : 'Cnfmd'
-                : 'Confirmed'}
-            </abbr>
-            <div
-              style={{
-                display:
-                  sortData.sortColumn === 'confirmed' ? 'initial' : 'none',
-              }}
-            >
-              {sortData.isAscending ? (
-                <div className="arrow-up" />
-              ) : (
-                <div className="arrow-down" />
-              )}
-            </div>
-          </div>
-        </td>
-        <td className="state-page-link" colSpan={3}>
-          <Link to={`state/${state.statecode}`}>
-            <div>
-              <abbr>Visit state page</abbr>
-              <Icon.ArrowRightCircle />
-            </div>
-          </Link>
-        </td>
-      </tr>
+          <tr className={`district-heading`}>
+            <td onClick={(e) => handleSort('district')}>
+              <div className="heading-content">
+                <abbr title="District">District</abbr>
+                <div
+                  style={{
+                    display:
+                      sortData.sortColumn === 'district' ? 'initial' : 'none',
+                  }}
+                >
+                  {sortData.isAscending ? (
+                    <div className="arrow-up" />
+                  ) : (
+                    <div className="arrow-down" />
+                  )}
+                </div>
+              </div>
+            </td>
+            <td onClick={(e) => handleSort('confirmed')}>
+              <div className="heading-content">
+                <abbr
+                  className={`${window.innerWidth <= 769 ? 'is-cherry' : ''}`}
+                  title="Confirmed"
+                >
+                  {window.innerWidth <= 769
+                    ? window.innerWidth <= 375
+                      ? 'C'
+                      : 'Cnfmd'
+                    : 'Confirmed'}
+                </abbr>
+                <div
+                  style={{
+                    display:
+                      sortData.sortColumn === 'confirmed' ? 'initial' : 'none',
+                  }}
+                >
+                  {sortData.isAscending ? (
+                    <div className="arrow-up" />
+                  ) : (
+                    <div className="arrow-down" />
+                  )}
+                </div>
+              </div>
+            </td>
+            <td className="state-page-link" colSpan={3}>
+              <Link to={`state/${state.statecode}`}>
+                <div>
+                  <abbr>Visit state page</abbr>
+                  <Icon.ArrowRightCircle />
+                </div>
+              </Link>
+            </td>
+          </tr>
+        </React.Fragment>
+      )}
 
       {sortedDistricts &&
+        showDistricts &&
         Object.keys(sortedDistricts)
           .filter((district) => district.toLowerCase() !== 'unknown')
           .map((district, index) => {
@@ -285,7 +287,6 @@ function Row(props) {
                   key={index}
                   className={`district ${index % 2 === 0 ? 'is-odd' : ''}`}
                   style={{
-                    display: props.reveal && !props.total ? '' : 'none',
                     background: index % 2 === 0 ? '#f8f9fa' : '',
                   }}
                   onMouseEnter={() =>
@@ -313,12 +314,9 @@ function Row(props) {
             return null;
           })}
 
-      {sortedDistricts?.Unknown && (
+      {sortedDistricts?.Unknown && showDistricts && (
         <React.Fragment>
-          <tr
-            className={`district`}
-            style={{display: props.reveal && !props.total ? '' : 'none'}}
-          >
+          <tr className={`district`}>
             <td className="unknown" style={{fontWeight: 600}}>
               Unknown
               <Tooltip

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -261,7 +261,7 @@ function Table(props) {
               if (index !== 0 && state.confirmed > 0) {
                 return (
                   <Row
-                    key={index}
+                    key={state.state}
                     index={index}
                     state={state}
                     total={false}


### PR DESCRIPTION
**Description of PR**
- Fixes the unnecessary district information being rendered on initial page load. Table will now render only the states information and will render districts information only when user clicks or taps on the state name/s.
- The number of DOM elements rendered on initial page load went down from 4800 to less than 1500.
- Will help reduce render time and main thread work load and overall performance.

**Type of PR**
- [x] Bugfix

**Relevant Issues**  
Closes #1428

**Checklist**
- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [ ] Tested on phone