### PR TITLE
Style: Allow navbar's expanded state to overflow

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4544,6 +4544,8 @@ footer {
 
   .Navbar {
     .expand {
+      height: calc(100vh - 3.9rem);
+      overflow: auto;
       transform: none !important;
     }
 


### PR DESCRIPTION
**Description of PR**
* fix -- all navlinks are not visible in horizontal mobile view.

**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes #1440 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![scroll](https://user-images.githubusercontent.com/45959932/80086655-a7245500-8577-11ea-8522-448f77557f3a.gif)
