### PR TITLE
Improv: Fetch IST time instead of local time

### DIFF
--- a/src/components/Charts/allstates.js
+++ b/src/components/Charts/allstates.js
@@ -24,7 +24,7 @@ function AllStatesChart(props) {
 
     Object.keys(data).forEach((key) => {
       if (key === 'date') {
-        dates.push(moment(data.date.trim(), 'DD MMM'));
+        dates.push(moment(data.date.trim(), 'DD MMM').utcOffset('+05:30'));
       }
 
       if (key === 'status' || key === 'date') {

--- a/src/components/Charts/dailyconfirmedchart.js
+++ b/src/components/Charts/dailyconfirmedchart.js
@@ -22,7 +22,9 @@ function DailyConfirmedChart(props) {
 
   props.timeseries.forEach((data, index) => {
     if (index >= 31) {
-      dates.push(moment(data.date.trim(), 'DD MMM').format('DD MMM'));
+      dates.push(
+        moment(data.date.trim(), 'DD MMM').utcOffset('+05:30').format('DD MMM')
+      );
       confirmed.push(data.dailyconfirmed);
       recovered.push(data.dailyrecovered);
       deceased.push(data.dailydeceased);

--- a/src/components/Charts/growthtrendchart.js
+++ b/src/components/Charts/growthtrendchart.js
@@ -41,7 +41,7 @@ function GrowthTrendChart(props) {
 
     Object.keys(data).forEach((key) => {
       if (key === 'date') {
-        dates.push(moment(data.date.trim(), 'DD MMM'));
+        dates.push(moment(data.date.trim(), 'DD MMM').utcOffset('+05:30'));
       }
 
       if (key === 'status' || key === 'date') {

--- a/src/components/Charts/totalconfirmedchart.js
+++ b/src/components/Charts/totalconfirmedchart.js
@@ -17,7 +17,7 @@ function TotalConfirmedChart(props) {
 
   props.timeseries.forEach((data, index) => {
     if (index >= 31) {
-      dates.push(moment(data.date.trim(), 'DD MMM'));
+      dates.push(moment(data.date.trim(), 'DD MMM').utcOffset('+05:30'));
       confirmed.push(data.totalconfirmed);
       recovered.push(data.totalrecovered);
       deceased.push(data.totaldeceased);

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -387,9 +387,12 @@ function TimeSeries(props) {
     }
   }, [timeseries, graphData]);
 
-  const focusDate = moment(datapoint.date);
+  const focusDate = moment(datapoint.date).utcOffset('+05:30');
   let dateStr = focusDate.format('DD MMMM');
-  dateStr += focusDate.isSame(moment().subtract(1, 'days'), 'day')
+  dateStr += focusDate.isSame(
+    moment().utcOffset('+05:30').subtract(1, 'days'),
+    'day'
+  )
     ? ' Yesterday'
     : '';
 

--- a/src/utils/commonfunctions.js
+++ b/src/utils/commonfunctions.js
@@ -37,8 +37,6 @@ export const formatDateAbsolute = (unformattedDate) => {
 };
 
 const validateCTS = (data = []) => {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
   const dataTypes = [
     'dailyconfirmed',
     'dailydeceased',
@@ -51,8 +49,11 @@ const validateCTS = (data = []) => {
     .filter((d) => dataTypes.every((dt) => d[dt]) && d.date)
     .filter((d) => dataTypes.every((dt) => Number(d[dt]) >= 0))
     .filter((d) => {
-      const year = today.getFullYear();
-      return new Date(d.date + year) < today;
+      // Skip data from the current day
+      const today = moment().utcOffset('+05:30');
+      return moment(d.date, 'DD MMMM')
+        .utcOffset('+05:30')
+        .isBefore(today, 'day');
     });
 };
 
@@ -95,11 +96,11 @@ export const parseStateTimeseries = ({states_daily: data}) => {
     return a;
   }, {});
 
-  const today = moment();
+  const today = moment().utcOffset('+05:30');
   for (let i = 0; i < data.length; i += 3) {
-    const date = moment(data[i].date, 'DD-MMM-YY');
+    const date = moment(data[i].date, 'DD-MMM-YY').utcOffset('+05:30');
     // Skip data from the current day
-    if (date.isBefore(today, 'Date')) {
+    if (date.isBefore(today, 'day')) {
       Object.entries(statewiseSeries).forEach(([k, v]) => {
         const stateCode = k.toLowerCase();
         const prev = v[v.length - 1] || {};


### PR DESCRIPTION
**Description of PR**
This PR fetches the time in IST instead of depending on the user's local time. Hence, people viewing the data from timezones other than IST will be able to see the latest data.

**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes #1100 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
<img width="1440" alt="Compare the two in a different timezone" src="https://user-images.githubusercontent.com/34034261/80088878-bce74980-857a-11ea-858d-58711818d37e.png">
I changed my system timezone to 'Samoa Standard Time' which was still on 22nd April, while IST was on 23rd April. Above screenshot shows that the left version(modified) has the latest graph, while the right version(un-modified) has graphs from one day ago.
