### PR TITLE
Fix: Hidden tooltip from table and out of screen tooltip (Home) page

### DIFF
--- a/src/components/row.js
+++ b/src/components/row.js
@@ -37,8 +37,8 @@ function Row(props) {
     tooltip: {
       background: '#000',
       borderRadius: '10px',
+      transform: 'translateX(-15px)',
       fontSize: '.8em',
-      left: '250%',
       opacity: 0.65,
     },
     wrapper: {
@@ -46,9 +46,10 @@ function Row(props) {
       display: 'inline-block',
       position: 'relative',
       textAlign: 'center',
+      zIndex: 9999,
     },
     arrow: {
-      left: '37%',
+      left: '8%',
     },
   };
 


### PR DESCRIPTION
**Description of PR**
* fixed hidden tooltip from table
* fixed getting out of screen tooltip

**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes #1442, Fixes #1380 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Screenshot from 2020-04-23 16-49-21](https://user-images.githubusercontent.com/45959932/80093979-13f11c80-8583-11ea-9084-f6e144fb772c.png)

![Screenshot from 2020-04-23 18-38-27](https://user-images.githubusercontent.com/45959932/80103306-aac4d580-8591-11ea-8763-6423263dea20.png)
