### PR TITLE
Fix: Always scroll to top on routing between pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Navbar from './components/navbar';
 import PatientDB from './components/patientdb';
 import Resources from './components/resources';
 import State from './components/state';
+import ScrollToTop from './utils/ScrollToTop';
 
 import React from 'react';
 import {
@@ -76,6 +77,7 @@ function App() {
   return (
     <div className={`App ${darkMode ? 'dark-mode' : ''}`}>
       <Router>
+        <ScrollToTop />
         <Route
           render={({location}) => (
             <div className="Almighty-Router">

--- a/src/utils/ScrollToTop.js
+++ b/src/utils/ScrollToTop.js
@@ -1,0 +1,12 @@
+import {useEffect} from 'react';
+import {useLocation} from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const {pathname} = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
**Description of PR**
*  Fix of on route change page is not render from top on deepdive(Desktop) and state page in mobile.

**Type of PR**

- [x] Bugfix

**Relevant Issues**  
Fixes #1453 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
#### Before Fix
![scroll issue](https://user-images.githubusercontent.com/45959932/80122182-cee0e080-85aa-11ea-8edb-d3aba577b110.gif)
<br>

#### after Fix
![scroll fix](https://user-images.githubusercontent.com/45959932/80122387-1b2c2080-85ab-11ea-8d15-275496a402b7.gif)

#### mobile view Fix
![mobfix](https://user-images.githubusercontent.com/45959932/80126181-59780e80-85b0-11ea-8818-491ee20ffc27.gif)
