### PR TITLE
Feat: Support notes as tooltips for district rows as well

### DIFF
--- a/src/components/row.js
+++ b/src/components/row.js
@@ -284,7 +284,19 @@ function Row(props) {
                   }
                   onMouseLeave={() => props.onHighlightDistrict?.()}
                 >
-                  <td style={{fontWeight: 600}}>{district}</td>
+                  <td className="unknown" style={{fontWeight: 600}}>
+                    {district}
+                    <span onClick={handleTooltip}>
+                      <span
+                        data-for="unknown"
+                        data-tip={[[sortedDistricts[district].notes]]}
+                        data-event="touchstart mouseover"
+                        data-event-off="mouseleave"
+                      >
+                        {sortedDistricts[district].notes && <Icon.Info />}
+                      </span>
+                    </span>
+                  </td>
                   <td>
                     <span className="deltas" style={{color: '#ff073a'}}>
                       {sortedDistricts[district].delta.confirmed > 0 && (
@@ -312,23 +324,14 @@ function Row(props) {
               <span onClick={handleTooltip}>
                 <span
                   data-for="unknown"
-                  data-tip={[
-                    'Awaiting patient-level details from State Bulletin',
-                  ]}
+                  data-tip={
+                    'Awaiting patient-level details from State Bulletin'
+                  }
                   data-event="touchstart mouseover"
                   data-event-off="mouseleave"
                 >
                   <Icon.Info />
                 </span>
-                <ReactTooltip
-                  id="unknown"
-                  place="right"
-                  type="dark"
-                  effect="solid"
-                  multiline={true}
-                  scrollHide={true}
-                  globalEventOff="click"
-                />
               </span>
             </td>
             <td>
@@ -342,6 +345,26 @@ function Row(props) {
               </span>
               <span className="table__count-text">
                 {formatNumber(sortedDistricts['Unknown'].confirmed)}
+              </span>
+            </td>
+          </tr>
+        </React.Fragment>
+      )}
+
+      {showDistricts && (
+        <React.Fragment>
+          <tr>
+            <td colSpan={2}>
+              <span className="unknown">
+                <ReactTooltip
+                  id="unknown"
+                  place="right"
+                  type="dark"
+                  effect="solid"
+                  multiline={true}
+                  scrollHide={true}
+                  globalEventOff="click"
+                />
               </span>
             </td>
           </tr>


### PR DESCRIPTION
**Description of PR**
Support notes as Tooltips for district rows

**Relevant Issues**  
Fixes #1472 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

At the time of pull request all district note were empty. If it receive a note it will look like this

<img width="372" alt="Screen Shot 2020-04-25 at 3 24 58 AM" src="https://user-images.githubusercontent.com/17938322/80266430-7e4dae00-86a4-11ea-944b-879815a908ac.png">