### PR TITLE
Feat: Highlight currently selected row in table

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1545,9 +1545,12 @@ table {
     tr {
       cursor: pointer;
 
+      &.is-highlighted {
+        background: $gray-hover !important;
+      }
+
       &:hover {
         background: $gray-hover !important;
-
 
         .dropdown {
           background: $gray-hover;

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -29,6 +29,11 @@ function Home(props) {
   const [fetched, setFetched] = useState(false);
   const [activeStateCode, setActiveStateCode] = useState('TT');
   const [regionHighlighted, setRegionHighlighted] = useState(undefined);
+  const [rowHighlighted, setRowHighlighted] = useState({
+    statecode: undefined,
+    isDistrict: false,
+    districtName: undefined,
+  });
   const [showUpdates, setShowUpdates] = useState(false);
   const [anchor, setAnchor] = useState(null);
   const [lastViewedLog, setLastViewedLog] = useLocalStorage(
@@ -110,8 +115,20 @@ function Home(props) {
     setRegionHighlighted({district, state, index});
   };
 
-  const onMapHighlightChange = useCallback(({statecode}) => {
-    setActiveStateCode(statecode);
+  const onMapHighlightChange = useCallback((region) => {
+    setActiveStateCode(region.statecode);
+    if ('districtName' in region)
+      setRowHighlighted({
+        statecode: region.statecode,
+        isDistrict: true,
+        districtName: region.districtName,
+      });
+    else
+      setRowHighlighted({
+        statecode: region.statecode,
+        isDistrict: false,
+        districtName: undefined,
+      });
   }, []);
 
   return (
@@ -159,6 +176,7 @@ function Home(props) {
               states={states}
               summary={false}
               stateDistrictWiseData={stateDistrictWiseData}
+              rowHighlighted={rowHighlighted}
               onHighlightState={onHighlightState}
               onHighlightDistrict={onHighlightDistrict}
             />

--- a/src/components/mapexplorer.js
+++ b/src/components/mapexplorer.js
@@ -123,6 +123,7 @@ function MapExplorer({
         setPanelRegion(panelRegion);
         currentHoveredRegion.statecode = panelRegion.statecode;
         setCurrentHoveredRegion(currentHoveredRegion);
+        panelRegion.districtName = currentHoveredRegion.name;
         if (onMapHighlightChange) onMapHighlightChange(panelRegion);
       }
     },

--- a/src/components/row.js
+++ b/src/components/row.js
@@ -98,7 +98,7 @@ function Row(props) {
       <tr
         className={`state ${props.total ? 'is-total' : ''} ${
           props.index % 2 === 0 ? 'is-odd' : ''
-        }`}
+        } ${props.isHighlighted ? 'is-highlighted' : ''}`}
         onMouseEnter={() => props.onHighlightState?.(state, props.index)}
         onMouseLeave={() => props.onHighlightState?.()}
         onClick={!props.total ? handleReveal : null}
@@ -275,7 +275,11 @@ function Row(props) {
               return (
                 <tr
                   key={index}
-                  className={`district ${index % 2 === 0 ? 'is-odd' : ''}`}
+                  className={`district ${index % 2 === 0 ? 'is-odd' : ''} ${
+                    props.highlightedDistrict === district
+                      ? 'is-highlighted'
+                      : ''
+                  }`}
                   style={{
                     background: index % 2 === 0 ? '#f8f9fa' : '',
                   }}

--- a/src/components/table.js
+++ b/src/components/table.js
@@ -3,8 +3,11 @@ import Row from './row';
 import React, {useState, useEffect} from 'react';
 import {Link} from 'react-router-dom';
 
-const isEqual = () => {
-  return true;
+const isEqual = (prevProps, currProps) => {
+  return (
+    JSON.stringify(prevProps.rowHighlighted) ===
+    JSON.stringify(currProps.rowHighlighted)
+  );
 };
 
 function Table(props) {
@@ -270,6 +273,16 @@ function Table(props) {
                       state.state in districts
                         ? districts[state.state].districtData
                         : []
+                    }
+                    isHighlighted={
+                      !props.rowHighlighted.isDistrict &&
+                      props.rowHighlighted.statecode === state.statecode
+                    }
+                    highlightedDistrict={
+                      props.rowHighlighted.isDistrict &&
+                      props.rowHighlighted.statecode === state.statecode
+                        ? props.rowHighlighted.districtName
+                        : null
                     }
                     onHighlightState={props.onHighlightState}
                     onHighlightDistrict={props.onHighlightDistrict}


### PR DESCRIPTION
**Description of PR**
This PR highlights the currently selected row in table on change in map and timeseries charts. It has the same style as it is when hover.

**Relevant Issues**  
Fixes #1473

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/11428805/80189229-fded6580-862f-11ea-9d9d-9ccc3af9aab3.gif)
