### PR TITLE
Fix: Show remove icon even for zero search results

### DIFF
--- a/src/components/search.js
+++ b/src/components/search.js
@@ -146,7 +146,7 @@ function Search(props) {
         <Icon.Search />
       </div>
 
-      {results.length > 0 && (
+      {searchValue.length > 0 && (
         <div
           className={`close-button`}
           onClick={() => {


### PR DESCRIPTION

**Description of PR**
Fixed the bug Remove icon disappears if search value is not in the search results

**Relevant Issues**  
Fixes #1430 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Add relevant screenshots here

![image](https://user-images.githubusercontent.com/11550572/80211511-7f0a2400-8653-11ea-92ff-ea91e848f5fc.png)
![image](https://user-images.githubusercontent.com/11550572/80211555-8f220380-8653-11ea-9a71-1a075021d48b.png)

