### PR TITLE
Update commonfunctions.js

### DIFF
--- a/src/utils/commonfunctions.js
+++ b/src/utils/commonfunctions.js
@@ -69,7 +69,7 @@ export const preprocessTimeseries = (timeseries) => {
     totalactive:
       +stat.totalconfirmed - +stat.totalrecovered - +stat.totaldeceased,
     dailyactive:
-      +stat.dailyconfirmed - +stat.dailyrecovered - +stat.dailydeceased,
+      +stat.totalconfirmed - +stat.totalrecovered - +stat.totaldeceased,
   }));
 };
 
@@ -123,7 +123,7 @@ export const parseStateTimeseries = ({states_daily: data}) => {
           totaldeceased: totaldeceased,
           // Active = Confimed - Recovered - Deceased
           totalactive: totalconfirmed - totalrecovered - totaldeceased,
-          dailyactive: dailyconfirmed - dailyrecovered - dailydeceased,
+          dailyactive: totalconfirmed - totalrecovered - totaldeceased,
         });
       });
     }


### PR DESCRIPTION
Daily Active is same as Total active. 
Else you will have negative Daily Active cases on days more people healed and died than got infected

**Description of PR**

Fix Daily Active graph, which can show negative numbers (obviously incorrect)

**Relevant Issues**  
Fixes #...

**Checklist**

- [x ] Compiles and passes lint tests
- [x ] Properly formatted
- [ ] Tested on desktop
- [ ] Tested on phone

**Screenshots**

Add relevant screenshots here
