### PR TITLE
Style: Fix visibility of state, city and services drop-downs

### DIFF
--- a/src/components/Essentials/essentialsfiltersdesktop.js
+++ b/src/components/Essentials/essentialsfiltersdesktop.js
@@ -35,7 +35,8 @@ const useInputLabelStyles = makeStyles(() => ({
 const useMenuItemStyles = makeStyles(() => ({
   root: {
     fontFamily: 'archia',
-    fontSize: '11.5px !important',
+    fontSize: '11px !important',
+    minHeight: '14px',
     fontWeight: 600,
     textTransform: 'uppercase',
   },

--- a/src/components/Essentials/essentialsfiltersdesktop.js
+++ b/src/components/Essentials/essentialsfiltersdesktop.js
@@ -35,7 +35,7 @@ const useInputLabelStyles = makeStyles(() => ({
 const useMenuItemStyles = makeStyles(() => ({
   root: {
     fontFamily: 'archia',
-    fontSize: '11px !important',
+    fontSize: '11.5px !important',
     fontWeight: 600,
     textTransform: 'uppercase',
   },

--- a/src/components/Essentials/essentialsfiltersmobile.js
+++ b/src/components/Essentials/essentialsfiltersmobile.js
@@ -25,6 +25,7 @@ const useInputLabelStyles = makeStyles(() => ({
   root: {
     fontFamily: 'archia',
     fontSize: '11px !important',
+    minHeight: '14px',
     fontWeight: 600,
     textTransform: 'uppercase',
   },


### PR DESCRIPTION
**Description of PR**
My screen resolution is 1366x768. It is reproduced on 90% of my screen.
Fixed: State, City and Services drop-downs selected value is not fully visible issue.

**Relevant Issues**  
Fixes  #1469 

**Checklist**

- [ ] Properly formatted
- [ ] Tested on desktop
- [ ] Tested on phone

**Screenshots**
Before fix
<img width="1067" alt="covid19CSSissue" src="https://user-images.githubusercontent.com/16570665/80232064-e8009480-8671-11ea-9a66-deb1bd9a6462.png">

After fix
![Screenshot from 2020-04-24 21-40-52](https://user-images.githubusercontent.com/16570665/80233589-521a3900-8674-11ea-962e-e958c6303175.png)

Add relevant screenshots here
