### PR TITLE
Fix: Debounce input events on search in home page

### DIFF
--- a/src/components/search.js
+++ b/src/components/search.js
@@ -3,7 +3,7 @@ import {
   DISTRICTS_ARRAY,
   STATE_CODES_REVERSE,
 } from '../constants';
-import useDebounce from '../utils/hooks';
+import {useDebounce} from '../utils/hooks';
 
 import Bloodhound from 'corejs-typeahead';
 import React, {useState, useCallback, useRef, useEffect} from 'react';

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -3,9 +3,10 @@ import {
   DISTRICTS_ARRAY,
   STATE_CODES_REVERSE,
 } from '../constants';
+import useDebounce from '../utils/hooks';
 
 import Bloodhound from 'corejs-typeahead';
-import React, {useState, useCallback, useRef} from 'react';
+import React, {useState, useCallback, useRef, useEffect} from 'react';
 import * as Icon from 'react-feather';
 import {Link} from 'react-router-dom';
 
@@ -105,6 +106,14 @@ function Search(props) {
     districtEngine.search(searchInput, districtSync);
     essentialsEngine.search(searchInput, essentialsSync, essentialsAsync);
   }, []);
+
+  const debouncedSearchTerm = useDebounce(searchValue, 800);
+  useEffect(() => {
+    // Make sure we have a value (user has entered something in input)
+    if (debouncedSearchTerm) {
+      handleSearch(debouncedSearchTerm.toLowerCase());
+    }
+  }, [debouncedSearchTerm, handleSearch]);
 
   function setNativeValue(element, value) {
     const valueSetter = Object.getOwnPropertyDescriptor(element, 'value').set;

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -112,6 +112,8 @@ function Search(props) {
     // Make sure we have a value (user has entered something in input)
     if (debouncedSearchTerm) {
       handleSearch(debouncedSearchTerm.toLowerCase());
+    } else {
+      setResults([]);
     }
   }, [debouncedSearchTerm, handleSearch]);
 

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -3,12 +3,12 @@ import {
   DISTRICTS_ARRAY,
   STATE_CODES_REVERSE,
 } from '../constants';
-import {useDebounce} from '../utils/hooks';
 
 import Bloodhound from 'corejs-typeahead';
-import React, {useState, useCallback, useRef, useEffect} from 'react';
+import React, {useState, useCallback, useRef} from 'react';
 import * as Icon from 'react-feather';
 import {Link} from 'react-router-dom';
+import {useDebounce} from 'react-use';
 
 const engine = new Bloodhound({
   initialize: true,
@@ -107,17 +107,17 @@ function Search(props) {
     essentialsEngine.search(searchInput, essentialsSync, essentialsAsync);
   }, []);
 
-  // By using debounce you make network call only when user stops after typing some input.
-  // In this way it also avoids extra network calls.
-  const debouncedSearchTerm = useDebounce(searchValue, 800);
-  useEffect(() => {
-    // Make sure we have a value (user has entered something in input)
-    if (debouncedSearchTerm) {
-      handleSearch(debouncedSearchTerm.toLowerCase());
-    } else {
-      setResults([]);
-    }
-  }, [debouncedSearchTerm, handleSearch]);
+  useDebounce(
+    () => {
+      if (searchValue) {
+        handleSearch(searchValue.toLowerCase());
+      } else {
+        setResults([]);
+      }
+    },
+    800,
+    [searchValue]
+  );
 
   function setNativeValue(element, value) {
     const valueSetter = Object.getOwnPropertyDescriptor(element, 'value').set;

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -147,7 +147,6 @@ function Search(props) {
         }}
         onChange={(event) => {
           setSearchValue(event.target.value);
-          handleSearch(event.target.value.toLowerCase());
         }}
       />
 

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -107,7 +107,9 @@ function Search(props) {
     essentialsEngine.search(searchInput, essentialsSync, essentialsAsync);
   }, []);
 
-  const debouncedSearchTerm = useDebounce(searchValue, 800);
+  // By using debounce you make network call only when user waits after typing some input.
+  // In this way it also avoids extra network calls.
+  const debouncedSearchTerm = useDebounce(searchValue, 700);
   useEffect(() => {
     // Make sure we have a value (user has entered something in input)
     if (debouncedSearchTerm) {

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -109,7 +109,7 @@ function Search(props) {
 
   // By using debounce you make network call only when user stops after typing some input.
   // In this way it also avoids extra network calls.
-  const debouncedSearchTerm = useDebounce(searchValue, 700);
+  const debouncedSearchTerm = useDebounce(searchValue, 800);
   useEffect(() => {
     // Make sure we have a value (user has entered something in input)
     if (debouncedSearchTerm) {

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -107,7 +107,7 @@ function Search(props) {
     essentialsEngine.search(searchInput, essentialsSync, essentialsAsync);
   }, []);
 
-  // By using debounce you make network call only when user waits after typing some input.
+  // By using debounce you make network call only when user stops after typing some input.
   // In this way it also avoids extra network calls.
   const debouncedSearchTerm = useDebounce(searchValue, 700);
   useEffect(() => {

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -18,7 +18,7 @@ export const useResizeObserver = (ref) => {
   return dimensions;
 };
 
-export default function useDebounce(value, delay) {
+export function useDebounce(value, delay) {
   // State and setters for debounced value
   const [debouncedValue, setDebouncedValue] = useState(value);
 

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -17,34 +17,3 @@ export const useResizeObserver = (ref) => {
   }, [ref]);
   return dimensions;
 };
-
-export function useDebounce(value, delay) {
-  // State and setters for debounced value
-  const [debouncedValue, setDebouncedValue] = useState(value);
-
-  useEffect(
-    () => {
-      // Set debouncedValue to value (passed in) after the specified delay
-      const handler = setTimeout(() => {
-        setDebouncedValue(value);
-      }, delay);
-
-      // Return a cleanup function that will be called every time ...
-      // ... useEffect is re-called. useEffect will only be re-called ...
-      // ... if value changes (see the inputs array below).
-      // This is how we prevent debouncedValue from changing if value is ...
-      // ... changed within the delay period. Timeout gets cleared and restarted.
-      // To put it in context, if the user is typing within our app's ...
-      // ... search box, we don't want the debouncedValue to update until ...
-      // ... they've stopped typing for more than given delay.
-      return () => {
-        clearTimeout(handler);
-      };
-    },
-    // Only re-call effect if value changes
-    // You could also add the "delay" var to inputs array if you ...
-    // ... need to be able to change that dynamically.
-    [delay, value]
-  );
-  return debouncedValue;
-}

--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -17,3 +17,34 @@ export const useResizeObserver = (ref) => {
   }, [ref]);
   return dimensions;
 };
+
+export default function useDebounce(value, delay) {
+  // State and setters for debounced value
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(
+    () => {
+      // Set debouncedValue to value (passed in) after the specified delay
+      const handler = setTimeout(() => {
+        setDebouncedValue(value);
+      }, delay);
+
+      // Return a cleanup function that will be called every time ...
+      // ... useEffect is re-called. useEffect will only be re-called ...
+      // ... if value changes (see the inputs array below).
+      // This is how we prevent debouncedValue from changing if value is ...
+      // ... changed within the delay period. Timeout gets cleared and restarted.
+      // To put it in context, if the user is typing within our app's ...
+      // ... search box, we don't want the debouncedValue to update until ...
+      // ... they've stopped typing for more than given delay.
+      return () => {
+        clearTimeout(handler);
+      };
+    },
+    // Only re-call effect if value changes
+    // You could also add the "delay" var to inputs array if you ...
+    // ... need to be able to change that dynamically.
+    [delay, value]
+  );
+  return debouncedValue;
+}


### PR DESCRIPTION
**Description**

Fix the issue of Freezing of Search Bar while typing.
Used Debounce to fix the issue as well as to prevent unnecessary network calls & optimize the performance

**Relevant Issues**  
Fixes #1511 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

1. Typing Maharashtra
![Typing Maharashtra (1)](https://user-images.githubusercontent.com/14978241/80281701-a7b11d00-872a-11ea-88e4-46c408defd94.gif)



2. Typing Madhya Pradesh
![Typing Madhya Pradesh (1)](https://user-images.githubusercontent.com/14978241/80281709-b26bb200-872a-11ea-8a96-18dbce17bf56.gif)




