### PR TITLE
Fix: Removed arrow icon from total row

### DIFF
--- a/src/components/row.js
+++ b/src/components/row.js
@@ -106,18 +106,17 @@ function Row(props) {
       >
         <td style={{fontWeight: 600}}>
           <div className="table__title-wrapper">
-            <span
-              className={`dropdown ${
-                props.reveal && showDistricts
-                  ? 'rotateRightDown'
-                  : 'rotateDownRight'
-              }`}
-              onClick={() => {
-                handleReveal();
-              }}
-            >
-              <Icon.ChevronDown />
-            </span>
+            {!props.total && (
+              <span
+                className={`dropdown ${
+                  props.reveal && showDistricts
+                    ? 'rotateRightDown'
+                    : 'rotateDownRight'
+                }`}
+              >
+                <Icon.ChevronDown />
+              </span>
+            )}
             <span className="actual__title-wrapper">
               {state.state}
               {state.statenotes && (


### PR DESCRIPTION
If you click on the arrow icon in total row, it was throwing error in the console because the arrow icon has onClick event too.

**Description of PR**
- Removed arrow icon from total row
- Removed onClick event from arrow icon because its ancestor class already has it so, no need of it in arrow icon class.

**Relevant Issues**  
Fixes #1531 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

