### PR TITLE
Persist timeseries scale mode for state page

### DIFF
--- a/src/components/state.js
+++ b/src/components/state.js
@@ -19,6 +19,7 @@ import {format, parse} from 'date-fns';
 import React, {useRef, useState} from 'react';
 import * as Icon from 'react-feather';
 import {Link, useParams} from 'react-router-dom';
+import {useLocalStorage} from 'react-use';
 import {useMeasure, useEffectOnce} from 'react-use';
 
 function State(props) {
@@ -30,8 +31,14 @@ function State(props) {
   const [fetched, setFetched] = useState(false);
   const [timeseries, setTimeseries] = useState({});
   const [graphOption, setGraphOption] = useState(1);
-  const [timeseriesMode, setTimeseriesMode] = useState(true);
-  const [timeseriesLogMode, setTimeseriesLogMode] = useState(false);
+  const [timeseriesMode, setTimeseriesMode] = useLocalStorage(
+    'timeseriesMode',
+    true
+  );
+  const [timeseriesLogMode, setTimeseriesLogMode] = useLocalStorage(
+    'timeseriesLogMode',
+    false
+  );
   const [stateData, setStateData] = useState({});
   const [testData, setTestData] = useState({});
   const [sources, setSources] = useState({});


### PR DESCRIPTION
**Description of PR**
The values for scale modes (uniform and logarithmic) of the TimeSeries charts are not remembered across sessions **in the state pages**. #904 fixed it for the home page. This PR makes the same changes for the state pages.

**Relevant Issues**  
Fixes #1538

**Checklist**
- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
[Desktop](https://www.dropbox.com/s/i3npnkp2uxzy5fq/screenshot_desktop.png?dl=0) [Mobile](https://www.dropbox.com/s/xbp1i9unvoyxmqd/screenshot_mobile.png?dl=0)
