### PR TITLE
[Feat] Add captions for scale modes in timeseries explorer

### DIFF
--- a/src/components/timeseriesexplorer.js
+++ b/src/components/timeseriesexplorer.js
@@ -2,6 +2,7 @@ import TimeSeries from './timeseries';
 
 import React from 'react';
 import * as Icon from 'react-feather';
+import ReactTooltip from 'react-tooltip';
 import {useLocalStorage} from 'react-use';
 
 function TimeSeriesExplorer({
@@ -69,9 +70,23 @@ function TimeSeriesExplorer({
         </div>
 
         <div className="scale-modes">
+          <ReactTooltip id="timeseries" place="bottom" globalEventOff="click" />
           <label className="main">Scale Modes</label>
           <div className="timeseries-mode">
-            <label htmlFor="timeseries-mode">Uniform</label>
+            <label
+              htmlFor="timeseries-mode"
+              data-tip={
+                timeseriesMode
+                  ? 'Turn off to make Y-axes adjust to their own highest ranges'
+                  : 'Turn on to make Y-axes in below graphs match the same range'
+              }
+              data-for="timeseries"
+              data-border="true"
+              data-event="touchstart mouseover"
+              data-event-off="mouseleave"
+            >
+              Uniform
+            </label>
             <input
               id="timeseries-mode"
               type="checkbox"
@@ -88,7 +103,20 @@ function TimeSeriesExplorer({
               graphOption !== 1 ? 'disabled' : ''
             }`}
           >
-            <label htmlFor="timeseries-logmode">Logarithmic</label>
+            <label
+              htmlFor="timeseries-logmode"
+              data-tip={
+                timeseriesLogMode
+                  ? 'Turn off to make the Y-axes steps double linearly'
+                  : 'Turn on to make the Y-axes steps jump with exponents of 10'
+              }
+              data-for="timeseries"
+              data-border="true"
+              data-event="touchstart mouseover"
+              data-event-off="mouseleave"
+            >
+              Logarithmic
+            </label>
             <input
               id="timeseries-logmode"
               type="checkbox"


### PR DESCRIPTION
**Description of PR**

Brief, simple captions will be visible when user hovers( desktop ) or taps ( touchscreens ) below the 
'uniform' and 'logarithmic' check-boxes in the timeseries explorer component. 

**Relevant Issues**  
Fixes #1339

**Checklist**

- :heavy_check_mark: Compiles and passes lint tests
- :heavy_check_mark: Properly formatted
- :heavy_check_mark: Tested on desktop
- :heavy_check_mark: Tested on phone

**Screenshots**
![screenshot](https://user-images.githubusercontent.com/39964085/80288639-d5ac5680-8756-11ea-98cc-f165856e14e7.png)

