### PR TITLE
Improv: Adjust colours of the map in dark mode

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4885,7 +4885,7 @@ footer {
   .MapExplorer {
     #chart,
     #legend {
-      filter: invert(1) hue-rotate(150deg);
+      filter: invert(1) hue-rotate(180deg) url('#white-balance');
     }
 
     .legend {

--- a/src/components/choropleth.js
+++ b/src/components/choropleth.js
@@ -282,6 +282,16 @@ function ChoroplethMap({
           ref={choroplethLegend}
         ></svg>
       </div>
+      <svg>
+        <defs>
+          <filter id="white-balance" colorInterpolationFilters="sRGB">
+            <feColorMatrix
+              type="matrix"
+              values="0.9137 0 0 0 0.0863 0 0.9137 0 0 0.0863 0 0 0.8549 0 0.1451 0 0 0 1 0"
+            />
+          </filter>
+        </defs>
+      </svg>
     </div>
   );
 }


### PR DESCRIPTION
**Description of PR**

This PR adjusts the SVG filters in dark mode to match the dark mode colour scheme. 
- Added a custom SVG filter to correct the white balance of the map after colour inversion

**Relevant Issues**  
Fixes #1499

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![image](https://user-images.githubusercontent.com/27727946/80290136-2163fd80-8761-11ea-8053-ac5a2cc26dc6.png)
