### PR TITLE
Style: Dark mode palette for select dropdown

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2935,7 +2935,7 @@ footer {
       font-family: 'archia';
       font-size: 12px;
       font-weight: 900;
-      height: 2.05rem;
+      height: 2.19rem;
       margin: .2rem .1rem;
       padding: .5rem;
       padding-inline-start: 1px;
@@ -5010,9 +5010,17 @@ footer {
     }
   }
 
-  select {
-    background: #1e1e30 !important;
-    border-color: #1e1e30 !important;
+  .trends-state-name,
+  .select {
+    select {
+      background: #1e1e30;
+      background-image: linear-gradient(45deg, transparent 50%, $gray 50%),
+      linear-gradient(135deg, $gray 50%, transparent 50%);
+      background-position: calc(100% - 13px) 50%, calc(100% - 8px) 50%;
+      background-repeat: no-repeat;
+      background-size: 5px 5px, 5px 5px;
+      border-color: #9494941a;
+    }
   }
 
   input {
@@ -5167,6 +5175,11 @@ footer {
 
     .legend {
       background: #1e1e30 !important;
+    }
+
+    .react-date-picker {
+      background: #1e1e30;
+      border-color: #9494941a !important;
     }
 
     .modal-content {


### PR DESCRIPTION
**Description of PR**
* currently dropdown in dark mode is not visible properly. this PR will fix this issue.
* fix height of react-datepicker (otherwise react-date-picker is always smaller than other select it's looking odd both in light and dark mode).

**Relevant Issues**  
Fixes #1421 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Screenshot from 2020-04-26 02-55-16](https://user-images.githubusercontent.com/45959932/80291224-8facbe00-8769-11ea-883d-617745e76b78.png)
![Screenshot from 2020-04-26 03-14-34](https://user-images.githubusercontent.com/45959932/80291553-1ebad580-876c-11ea-84c0-b1690b66d1a3.png)

#### Before
![Screenshot from 2020-04-26 03-10-49](https://user-images.githubusercontent.com/45959932/80291539-eddaa080-876b-11ea-96dc-b7d8be3e006d.png)


#### After fix
![Screenshot from 2020-04-26 03-12-27](https://user-images.githubusercontent.com/45959932/80291542-f0d59100-876b-11ea-85a9-962db0a6add3.png)