### PR TITLE
Style: Wrap timeseries with timeSeriesExplorer in state page

### DIFF
--- a/src/components/state.js
+++ b/src/components/state.js
@@ -383,69 +383,71 @@ function State(props) {
                 </Link>
               )}
 
-              <div
-                className="timeseries-header fadeInUp"
-                style={{animationDelay: '2.5s'}}
-                ref={tsRef}
-              >
-                <div className="tabs">
-                  <div
-                    className={`tab ${graphOption === 1 ? 'focused' : ''}`}
-                    onClick={() => {
-                      setGraphOption(1);
-                    }}
-                  >
-                    <h4>Cumulative</h4>
+              <div className="TimeSeriesExplorer">
+                <div
+                  className="timeseries-header fadeInUp"
+                  style={{animationDelay: '2.5s'}}
+                  ref={tsRef}
+                >
+                  <div className="tabs">
+                    <div
+                      className={`tab ${graphOption === 1 ? 'focused' : ''}`}
+                      onClick={() => {
+                        setGraphOption(1);
+                      }}
+                    >
+                      <h4>Cumulative</h4>
+                    </div>
+                    <div
+                      className={`tab ${graphOption === 2 ? 'focused' : ''}`}
+                      onClick={() => {
+                        setGraphOption(2);
+                      }}
+                    >
+                      <h4>Daily</h4>
+                    </div>
                   </div>
-                  <div
-                    className={`tab ${graphOption === 2 ? 'focused' : ''}`}
-                    onClick={() => {
-                      setGraphOption(2);
-                    }}
-                  >
-                    <h4>Daily</h4>
+
+                  <div className="scale-modes">
+                    <label className="main">Scale Modes</label>
+                    <div className="timeseries-mode">
+                      <label htmlFor="timeseries-mode">Uniform</label>
+                      <input
+                        type="checkbox"
+                        checked={timeseriesMode}
+                        className="switch"
+                        aria-label="Checked by default to scale uniformly."
+                        onChange={(event) => {
+                          setTimeseriesMode(!timeseriesMode);
+                        }}
+                      />
+                    </div>
+                    <div
+                      className={`timeseries-logmode ${
+                        graphOption !== 1 ? 'disabled' : ''
+                      }`}
+                    >
+                      <label htmlFor="timeseries-logmode">Logarithmic</label>
+                      <input
+                        type="checkbox"
+                        checked={graphOption === 1 && timeseriesLogMode}
+                        className="switch"
+                        disabled={graphOption !== 1}
+                        onChange={(event) => {
+                          setTimeseriesLogMode(!timeseriesLogMode);
+                        }}
+                      />
+                    </div>
                   </div>
                 </div>
 
-                <div className="scale-modes">
-                  <label className="main">Scale Modes</label>
-                  <div className="timeseries-mode">
-                    <label htmlFor="timeseries-mode">Uniform</label>
-                    <input
-                      type="checkbox"
-                      checked={timeseriesMode}
-                      className="switch"
-                      aria-label="Checked by default to scale uniformly."
-                      onChange={(event) => {
-                        setTimeseriesMode(!timeseriesMode);
-                      }}
-                    />
-                  </div>
-                  <div
-                    className={`timeseries-logmode ${
-                      graphOption !== 1 ? 'disabled' : ''
-                    }`}
-                  >
-                    <label htmlFor="timeseries-logmode">Logarithmic</label>
-                    <input
-                      type="checkbox"
-                      checked={graphOption === 1 && timeseriesLogMode}
-                      className="switch"
-                      disabled={graphOption !== 1}
-                      onChange={(event) => {
-                        setTimeseriesLogMode(!timeseriesLogMode);
-                      }}
-                    />
-                  </div>
-                </div>
+                <TimeSeries
+                  timeseries={timeseries}
+                  type={graphOption}
+                  mode={timeseriesMode}
+                  logMode={timeseriesLogMode}
+                />
               </div>
-
-              <TimeSeries
-                timeseries={timeseries}
-                type={graphOption}
-                mode={timeseriesMode}
-                logMode={timeseriesLogMode}
-              />
             </React.Fragment>
           )}
         </div>


### PR DESCRIPTION
**Description of PR**
For mobile devices, width of timeseries charts is 100%. This PR fix it by wrapping everything inside TimeSeriesExplorer class same as that in homepage.

**Relevant Issues**  
Fixes #1536 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Screenshot_20200426-041622](https://user-images.githubusercontent.com/11428805/80292574-df44b700-8774-11ea-98ed-aa1c9069bb31.jpg)
