### PR TITLE
Fix: Support box-shadow property in all browsers

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -973,8 +973,13 @@ h6 {
   }
 
   input {
-    -webkit-box-shadow: 0 10px 35px rgba(0, 0, 0, .1);
     background: #fff;
+    height: 2rem;
+    width: calc(100% - 4rem);
+    box-shadow: 0 10px 35px rgba(0,0,0,.1);
+    -webkit-appearance: none !important;
+    -webkit-box-shadow: 0 10px 35px rgba(0,0,0,.1);
+    -moz-box-shadow: 0 10px 35px rgba(0,0,0,.1);
     border: 0;
     border-radius: 5px;
     box-shadow: 0 10px 35px rgba(0, 0, 0, .1);


### PR DESCRIPTION
**Description of PR**

Search text box without border in white color background is very difficult to find (mobile) .
Added necessary browser compatible webkit fixed the issue.

**Relevant Issues**  
Fixes #1558 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

![image](https://user-images.githubusercontent.com/7721961/80299220-66635080-87b0-11ea-8636-a10642955931.png)
