### PR TITLE
Improv: Exclude testing charts from uniform scaling

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2323,6 +2323,11 @@ table {
     height: 10rem;
     margin-bottom: 1rem;
   }
+
+  .alert {
+    position: absolute;
+    bottom: -4rem;
+  }
 }
 
 .timeseries-header {

--- a/src/components/deltabargraph.js
+++ b/src/components/deltabargraph.js
@@ -48,10 +48,8 @@ function DeltaBarGraph({timeseries, arrayKey}) {
       .call((g) => g.select('.domain').remove())
       .selectAll('text')
       .attr('y', 0)
-      .attr('x', -40)
-      .attr('dy', '.35em')
-      .attr('transform', 'rotate(-90)')
-      .style('text-anchor', 'start');
+      .attr('dy', '1.5em')
+      .style('text-anchor', 'middle');
 
     svg
       .selectAll('.bar')

--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -4,6 +4,7 @@ import {useResizeObserver} from '../utils/hooks';
 import * as d3 from 'd3';
 import moment from 'moment';
 import React, {useState, useEffect, useRef, useCallback} from 'react';
+import * as Icon from 'react-feather';
 
 function TimeSeries(props) {
   const [lastDaysCount, setLastDaysCount] = useState(
@@ -135,20 +136,10 @@ function TimeSeries(props) {
 
       let yScales;
       if (plotTotal) {
-        let uniformScaleMin = Infinity;
-        dataTypesTotal.forEach((type) => {
-          uniformScaleMin = Math.min(
-            uniformScaleMin,
-            d3.min(timeseries, (d) => (isNaN(d[type]) ? 0 : d[type]))
-          );
-        });
-        let uniformScaleMax = 0;
-        dataTypesTotal.forEach((type) => {
-          uniformScaleMax = Math.max(
-            uniformScaleMax,
-            d3.max(timeseries, (d) => (isNaN(d[type]) ? 0 : d[type]))
-          );
-        });
+        const uniformScaleMin = d3.min(timeseries, (d) =>
+          Math.min(d.totalactive, d.totalrecovered, d.totaldeceased)
+        );
+        const uniformScaleMax = d3.max(timeseries, (d) => d.totalconfirmed);
         const yScaleUniformLinear = d3
           .scaleLinear()
           .clamp(true)
@@ -188,8 +179,9 @@ function TimeSeries(props) {
             ])
             .nice()
             .range([chartBottom, margin.top]);
-          if (logMode) return mode ? yScaleUniformLog : yScaleLog;
-          else return mode ? yScaleUniformLinear : yScaleLinear;
+          if (mode && type !== 'totaltested')
+            return logMode ? yScaleUniformLog : yScaleUniformLinear;
+          else return logMode ? yScaleLog : yScaleLinear;
         });
       } else {
         const yScaleDailyUniform = d3
@@ -213,6 +205,7 @@ function TimeSeries(props) {
           .range([chartBottom, margin.top]);
 
         yScales = dataTypesDaily.map((type) => {
+          if (mode) return yScaleDailyUniform;
           const yScaleLinear = d3
             .scaleLinear()
             .clamp(true)
@@ -226,7 +219,7 @@ function TimeSeries(props) {
             ])
             .nice()
             .range([chartBottom, margin.top]);
-          return mode ? yScaleDailyUniform : yScaleLinear;
+          return yScaleLinear;
         });
       }
 
@@ -516,6 +509,12 @@ function TimeSeries(props) {
             </svg>
           </div>
         )}
+        <div className="alert is-purple">
+          <Icon.AlertOctagon />
+          <div className="alert-right">
+            Tested chart is independent of uniform scaling
+          </div>
+        </div>
       </div>
 
       <div className="pills">


### PR DESCRIPTION
**Description of PR**
Testing charts are now scaled independently from the others.
- Also removed rotation of axis labels of bar chart in state pages

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![image](https://user-images.githubusercontent.com/27727946/80300439-741dd380-87ba-11ea-9807-885f2d9d530b.png)

![image](https://user-images.githubusercontent.com/27727946/80301268-c7932000-87c0-11ea-9391-9cd64f0dd9c2.png)

