### PR TITLE
Improv: Hide view all button for states having less districts

### DIFF
--- a/src/components/state.js
+++ b/src/components/state.js
@@ -369,9 +369,16 @@ function State(props) {
                             })
                         : ''}
                     </div>
-                    <button className="button" onClick={toggleShowAllDistricts}>
-                      {showAllDistricts ? `View less` : `View all`}
-                    </button>
+                    {districtData[stateName] &&
+                      Object.keys(districtData[stateName].districtData).length >
+                        5 && (
+                        <button
+                          className="button"
+                          onClick={toggleShowAllDistricts}
+                        >
+                          {showAllDistricts ? `View less` : `View all`}
+                        </button>
+                      )}
                   </div>
                   <div className="district-bar-right">
                     <div


### PR DESCRIPTION
**Description of PR**
* this PR will remove view all btn for states having top districts less than or equal to 5.

**Relevant Issues**  
Fixes #1583 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![fix view all](https://user-images.githubusercontent.com/45959932/80318671-4f147980-8829-11ea-9f28-9c19f75d39be.gif)
