### PR TITLE
Default tab to Daily in Spread Trend

### DIFF
--- a/src/components/timeseriesexplorer.js
+++ b/src/components/timeseriesexplorer.js
@@ -51,20 +51,20 @@ function TimeSeriesExplorer({
         <h1>Spread Trends</h1>
         <div className="tabs">
           <div
-            className={`tab ${graphOption === 1 ? 'focused' : ''}`}
-            onClick={() => {
-              setGraphOption(1);
-            }}
-          >
-            <h4>Cumulative</h4>
-          </div>
-          <div
             className={`tab ${graphOption === 2 ? 'focused' : ''}`}
             onClick={() => {
               setGraphOption(2);
             }}
           >
             <h4>Daily</h4>
+          </div>
+          <div
+            className={`tab ${graphOption === 1 ? 'focused' : ''}`}
+            onClick={() => {
+              setGraphOption(1);
+            }}
+          >
+            <h4>Cumulative</h4>
           </div>
         </div>
 


### PR DESCRIPTION
**Description of PR**

This is from user's experience perspective. I realised that most of the time, I look for daily trends instead of cumulative trends (in Spread Trends). I surveyed around 30 people (with varied background, gender, age) and found that most (29/30) of the people are more interested in _Daily Trends_ than in _Cumulativee Trends_. Although the sample size is very small, but I have good confidence about more people are looking for the _Daily Trends_. This PR makes _Daily Trends_ as default tab.

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Before
![Selection_041](https://user-images.githubusercontent.com/8968547/80353538-23c67480-8893-11ea-8946-9ce8680c4aff.png)

After
![Selection_042](https://user-images.githubusercontent.com/8968547/80353559-27f29200-8893-11ea-8b8c-530bfa72b682.png)

