### PR TITLE
Fix: Logarithmic scale issue

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -154,7 +154,7 @@ function TimeSeries(props) {
           .clamp(true)
           .domain([
             Math.max(1, uniformScaleMin),
-            Math.max(1, yBufferTop * uniformScaleMax),
+            Math.max(10, yBufferTop * uniformScaleMax),
           ])
           .nice()
           .range([chartBottom, margin.top]);
@@ -177,7 +177,7 @@ function TimeSeries(props) {
                 1,
                 d3.min(timeseries, (d) => d[type])
               ),
-              Math.max(1, yBufferTop * d3.max(timeseries, (d) => d[type])),
+              Math.max(10, yBufferTop * d3.max(timeseries, (d) => d[type])),
             ])
             .nice()
             .range([chartBottom, margin.top]);


### PR DESCRIPTION
**Description of PR**
The PR fixes issue on logarithmic scale when value is always zero on y-axis. In case of Sikkim, domain min and domain max of chart were same i.e 1 so, the plot has only one tick on y-axis and graph seems weird. I made min and max different which fixed it.

**Relevant Issues**  
Fixes #1585 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
Before
![Screenshot (57)](https://user-images.githubusercontent.com/11428805/80387562-68b7ce80-88c6-11ea-8a2d-fcd93e656af1.png)
After
![Screenshot (58)](https://user-images.githubusercontent.com/11428805/80387567-6b1a2880-88c6-11ea-8f39-d702b400c8e0.png)


