### PR TITLE
improv: Darkmode prefers color scheme

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ import {
   Redirect,
   Switch,
 } from 'react-router-dom';
-import {useLocalStorage} from 'react-use';
+import {useLocalStorage, useEffectOnce} from 'react-use';
 
 const schemaMarkup = {
   '@context': 'http://schema.org/',
@@ -75,6 +75,23 @@ function App() {
   ];
 
   const [darkMode, setDarkMode] = useLocalStorage('darkMode', false);
+  const [isThemeSet] = useLocalStorage('isThemeSet', false);
+
+  useEffectOnce(() => {
+    if (
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches &&
+      !isThemeSet
+    ) {
+      setDarkMode(true);
+    } else if (
+      window.matchMedia &&
+      !window.matchMedia('(prefers-color-scheme: dark)').matches &&
+      !isThemeSet
+    ) {
+      setDarkMode(false);
+    }
+  });
 
   React.useEffect(() => {
     if (darkMode) {
@@ -85,7 +102,7 @@ function App() {
   }, [darkMode]);
 
   return (
-    <div className={`App ${darkMode ? 'dark-mode' : ''}`}>
+    <div className="App">
       <Helmet>
         <script type="application/ld+json">
           {JSON.stringify(schemaMarkup)}

--- a/src/App.scss
+++ b/src/App.scss
@@ -113,6 +113,10 @@ h6 {
   font-weight: 600;
 }
 
+.App {
+  min-height: 100vh;
+}
+
 .switch-wrapper {
   position: relative;
 }

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -2,7 +2,12 @@ import anime from 'animejs';
 import React, {useState, useRef} from 'react';
 import * as Icon from 'react-feather';
 import {Link} from 'react-router-dom';
-import {useEffectOnce, useLockBodyScroll, useWindowSize} from 'react-use';
+import {
+  useEffectOnce,
+  useLockBodyScroll,
+  useWindowSize,
+  useLocalStorage,
+} from 'react-use';
 
 const navLinkProps = (path, animationDelay) => ({
   className: `fadeInUp ${window.location.pathname === path ? 'focused' : ''}`,
@@ -19,15 +24,20 @@ const activeNavIcon = (path) => ({
 
 function Navbar({pages, darkMode, setDarkMode}) {
   const [expand, setExpand] = useState(false);
-  useLockBodyScroll(expand);
+  // eslint-disable-next-line
+  const [isThemeSet, setIsThemeSet] = useLocalStorage('isThemeSet', false);
 
+  useLockBodyScroll(expand);
   const windowSize = useWindowSize();
 
   return (
     <div className="Navbar">
       <div
         className="navbar-left"
-        onClick={() => setDarkMode((prevMode) => !prevMode)}
+        onClick={() => {
+          setDarkMode((prevMode) => !prevMode);
+          setIsThemeSet(true);
+        }}
       >
         {darkMode ? <Icon.Sun color={'#ffc107'} /> : <Icon.Moon />}
       </div>


### PR DESCRIPTION
**Description of PR**
* setDarkMode on prefers-color-scheme media feature is used to detect if the user has requested the page to use a light or dark color theme.
* also fix flickering of app when app open in dark mode.

**Relevant Issues**  
Fixes #1569 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [ ] Tested on desktop
- [x] Tested on phone

**Screenshots**
![20200427_215432](https://user-images.githubusercontent.com/45959932/80399137-580f5480-88d6-11ea-8887-c4131666ac1c.gif)

