### PR TITLE
Fix: Don't show date twice in updates

### DIFF
--- a/src/components/updates.js
+++ b/src/components/updates.js
@@ -1,9 +1,10 @@
 import axios from 'axios';
 import {formatDistance, format} from 'date-fns';
-import React, {useState} from 'react';
+import React, {useState, useLayoutEffect} from 'react';
 import {useEffectOnce} from 'react-use';
 
-let currentDate = new Date();
+const newDate = new Date();
+let currentDate = newDate;
 
 function Updates(props) {
   const [updates, setUpdates] = useState([]);
@@ -17,6 +18,12 @@ function Updates(props) {
       .catch((err) => {
         console.log(err);
       });
+  });
+
+  // reset the currentDate after rendering is complete
+  // in case the currentDate was changed during addHeader
+  useLayoutEffect(() => {
+    currentDate = newDate;
   });
 
   return (


### PR DESCRIPTION
**Description of PR**

This was not a time issue. This was happening when the `bell icon` was pressed for the **second time** and the **current date had fewer than 5 updates**. 

`currentDate` was getting re-assigned during `addHeader()`. While this
has been fixed using hooks for now, a better approach for the
whole "adding-header" functionality is needed IMO.

**Relevant Issues**  
Fixes #1617 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Add relevant screenshots here
