### PR TITLE
Feat: active, recovered, and deceased stats on delta bar graph

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4490,24 +4490,6 @@ footer {
           font-family: 'archia';
         }
 
-        .x-axis {
-          &.dailyconfirmed {
-            color: $red;
-          }
-
-          &.dailyactive {
-            color: $blue;
-          }
-
-          &.dailyrecovered {
-            color: $green;
-          }
-
-          &.dailydeceased {
-            color: $gray;
-          }
-        }
-
         .delta {
           fill: #dc3545;
           font-weight: 900;

--- a/src/App.scss
+++ b/src/App.scss
@@ -437,19 +437,6 @@ h6 {
     width: 100%;
   }
 
-  .district-bar-right {
-    display: flex;
-    justify-content: center;
-    position: relative;
-
-    .happy-sign {
-      display: flex;
-      flex-direction: row;
-      position: absolute;
-      top: 4rem;
-    }
-  }
-
   .MapExplorer,
   .meta-secondary {
     width: calc(100% - 3rem);
@@ -4436,43 +4423,30 @@ footer {
   }
 }
 
-.DeltaBarGraph {
-  svg {
-    width: 100%;
-
-    text {
-      font-family: 'archia';
-    }
-
-    // .x-axis {
-    //   .daliyconfirmed text {
-    //     color: $red;
-    //   }
-    // }
-
-    .delta {
-      font-weight: 900;
-
-      &.dailyconfirmed {
-        fill: #dc3545;
-      }
-    }
-
-    .percent {
-      fill: #dc354590;
-    }
-  }
-}
-
 .district-bar {
   align-self: center;
   flex-direction: row;
   justify-content: space-between;
 
   h2 {
-    color: $red;
     font-weight: 900;
     margin-bottom: .5rem;
+
+    &.confirmed {
+      color: $red;
+    }
+
+    &.active {
+      color: $blue;
+    }
+
+    &.recovered {
+      color: $green;
+    }
+
+    &.deceased {
+      color: $gray;
+    }
   }
 
   .district-bar-left {
@@ -4492,6 +4466,71 @@ footer {
 
       &:hover {
         background: $gray-hover;
+      }
+    }
+  }
+
+  .district-bar-right {
+    display: flex;
+    justify-content: center;
+    position: relative;
+
+    .happy-sign {
+      display: flex;
+      flex-direction: row;
+      position: absolute;
+      top: 4rem;
+    }
+
+    .DeltaBarGraph {
+      svg {
+        width: 100%;
+
+        text {
+          font-family: 'archia';
+        }
+
+        .x-axis {
+          &.dailyconfirmed {
+            color: $red;
+          }
+
+          &.dailyactive {
+            color: $blue;
+          }
+
+          &.dailyrecovered {
+            color: $green;
+          }
+
+          &.dailydeceased {
+            color: $gray;
+          }
+        }
+
+        .delta {
+          font-weight: 900;
+
+          &.dailyconfirmed {
+            fill: #dc3545;
+          }
+
+          &.dailyrecovered {
+            fill: #47a745;
+          }
+
+          &.dailyactive {
+            fill: #0479fb;
+          }
+
+          &.dailydeceased {
+            fill: #6b747c;
+          }
+        }
+
+        .percent {
+          fill: #dc354590;
+        }
       }
     }
   }
@@ -4543,15 +4582,45 @@ footer {
         margin-top: 4px;
 
         h6 {
-          color: $red-mid;
           margin: 0;
+
+          &.confirmed {
+            color: $red-mid;
+          }
+
+          &.active {
+            color: $blue-mid;
+          }
+
+          &.recovered {
+            color: $green-mid;
+          }
+
+          &.deceased {
+            color: $gray-mid;
+          }
         }
 
         svg {
-          color: $red-mid;
           stroke-width: 4;
           vertical-align: bottom;
           width: 10px;
+
+          &.confirmed {
+            color: $red-mid;
+          }
+
+          &.active {
+            color: $blue-mid;
+          }
+
+          &.recovered {
+            color: $green-mid;
+          }
+
+          &.deceased {
+            color: $gray-mid;
+          }
         }
 
         & > * {

--- a/src/App.scss
+++ b/src/App.scss
@@ -4509,23 +4509,8 @@ footer {
         }
 
         .delta {
+          fill: #dc3545;
           font-weight: 900;
-
-          &.dailyconfirmed {
-            fill: #dc3545;
-          }
-
-          &.dailyrecovered {
-            fill: #47a745;
-          }
-
-          &.dailyactive {
-            fill: #0479fb;
-          }
-
-          &.dailydeceased {
-            fill: #6b747c;
-          }
         }
 
         .percent {

--- a/src/App.scss
+++ b/src/App.scss
@@ -4441,13 +4441,21 @@ footer {
     width: 100%;
 
     text {
-      color: $red;
       font-family: 'archia';
     }
 
+    // .x-axis {
+    //   .daliyconfirmed text {
+    //     color: $red;
+    //   }
+    // }
+
     .delta {
-      fill: #dc3545;
       font-weight: 900;
+
+      &.dailyconfirmed {
+        fill: #dc3545;
+      }
     }
 
     .percent {

--- a/src/components/deltabargraph.js
+++ b/src/components/deltabargraph.js
@@ -45,6 +45,7 @@ function DeltaBarGraph({timeseries, arrayKey}) {
       .select('.x-axis')
       .style('transform', `translateY(${chartBottom}px)`)
       .call(xAxis)
+      .attr('class', `x-axis ${arrayKey}`)
       .call((g) => g.select('.domain').remove())
       .selectAll('text')
       .attr('y', 0)
@@ -65,13 +66,21 @@ function DeltaBarGraph({timeseries, arrayKey}) {
           barRadius
         )
       )
-      .attr('fill', (d, i) => (i < data.length - 1 ? '#dc354590' : '#dc3545'));
+      .attr('fill', (d, i) => {
+        if (arrayKey === 'dailyconfirmed')
+          return i < data.length - 1 ? '#dc354590' : '#dc3545';
+        else if (arrayKey === 'dailyrecovered')
+          return i < data.length - 1 ? '#47A74590' : '#47A745';
+        else if (arrayKey === 'dailyactive')
+          return i < data.length - 1 ? '#0479FB90' : '#0479FB';
+        else return i < data.length - 1 ? '#6B747C90' : '#6B747C';
+      });
 
     svg
       .selectAll('.delta')
       .data(data)
       .join('text')
-      .attr('class', 'delta')
+      .attr('class', `delta ${arrayKey}`)
       .attr('text-anchor', 'middle')
       .attr('font-size', '11px')
       .attr('x', (d) => xScale(formatTime(d.date)) + xScale.bandwidth() / 2)
@@ -79,6 +88,7 @@ function DeltaBarGraph({timeseries, arrayKey}) {
       .text((d) => d[arrayKey])
       .append('tspan')
       .attr('class', 'percent')
+      .attr('display', arrayKey !== 'dailyconfirmed' ? 'none' : '')
       .attr('x', (d) => xScale(formatTime(d.date)) + xScale.bandwidth() / 2)
       .attr('dy', '-1.2em')
       .text((d, i) =>

--- a/src/components/deltabargraph.js
+++ b/src/components/deltabargraph.js
@@ -1,18 +1,13 @@
 import * as d3 from 'd3';
 import React, {useEffect, useRef, useState} from 'react';
 
-function DeltaBarGraph({timeseries, arrayKeyProp}) {
+function DeltaBarGraph({timeseries, arrayKey}) {
   const [data, setData] = useState([]);
-  const [arrayKey, setArrayKey] = useState(`daily${arrayKeyProp}`);
   const svgRef = useRef();
 
   useEffect(() => {
     setData(timeseries);
   }, [timeseries]);
-
-  useEffect(() => {
-    if (arrayKeyProp) setArrayKey(`daily${arrayKeyProp}`);
-  }, [arrayKeyProp, setArrayKey]);
 
   useEffect(() => {
     if (!data.length) return;
@@ -131,10 +126,9 @@ function DeltaBarGraph({timeseries, arrayKeyProp}) {
   );
 }
 
-export default React.memo(DeltaBarGraph);
-// export default React.memo(DeltaBarGraph, () => {
-//   return true;
-// });
+export default React.memo(DeltaBarGraph, (prevProps, nextProps) => {
+  return prevProps === nextProps;
+});
 
 function roundedBar(x, y, w, h, r, f, v) {
   if (!h) return;

--- a/src/components/deltabargraph.js
+++ b/src/components/deltabargraph.js
@@ -28,7 +28,7 @@ function DeltaBarGraph({timeseries, arrayKeyProp}) {
     if (arrayKey === 'dailyactive') {
       for (const day of data) {
         if (day[arrayKey] < 0) {
-          chartBottom = height - margin.bottom * 2.2;
+          chartBottom = height - margin.bottom * 2;
         }
       }
     }
@@ -75,7 +75,9 @@ function DeltaBarGraph({timeseries, arrayKeyProp}) {
           chartBottom,
           xScale.bandwidth(),
           chartBottom - yScale(d[arrayKey]),
-          barRadius
+          barRadius,
+          d[arrayKey] >= 0 ? 1 : 0,
+          d[arrayKey]
         )
       )
       .attr('fill', (d, i) => {
@@ -92,17 +94,15 @@ function DeltaBarGraph({timeseries, arrayKeyProp}) {
       .selectAll('.delta')
       .data(data)
       .join('text')
-      .attr('class', `delta ${arrayKey}`)
+      .attr('class', 'delta')
+      .attr('display', arrayKey !== 'dailyconfirmed' ? 'none' : '')
       .attr('text-anchor', 'middle')
       .attr('font-size', '11px')
       .attr('x', (d) => xScale(formatTime(d.date)) + xScale.bandwidth() / 2)
-      .attr('y', (d) =>
-        d[arrayKey] >= 0 ? yScale(d[arrayKey]) - 6 : yScale(d[arrayKey]) + 12
-      )
+      .attr('y', (d) => yScale(d[arrayKey]) - 6)
       .text((d) => d[arrayKey])
       .append('tspan')
       .attr('class', 'percent')
-      .attr('display', arrayKey !== 'dailyconfirmed' ? 'none' : '')
       .attr('x', (d) => xScale(formatTime(d.date)) + xScale.bandwidth() / 2)
       .attr('dy', '-1.2em')
       .text((d, i) =>
@@ -136,15 +136,13 @@ export default React.memo(DeltaBarGraph);
 //   return true;
 // });
 
-function roundedBar(x, y, w, h, r, f) {
+function roundedBar(x, y, w, h, r, f, v) {
   if (!h) return;
-  // Flag for sweep:
-  if (f === undefined) f = 1;
   // x coordinates of top of arcs
   const x0 = x + r;
   const x1 = x + w - r;
   // y coordinates of bottom of arcs
-  const y0 = y - h + r;
+  const y0 = v >= 0 ? y - h + r : y - h - r;
 
   const parts = [
     'M',

--- a/src/components/deltabargraph.js
+++ b/src/components/deltabargraph.js
@@ -1,13 +1,18 @@
 import * as d3 from 'd3';
 import React, {useEffect, useRef, useState} from 'react';
 
-function DeltaBarGraph({timeseries, arrayKey}) {
+function DeltaBarGraph({timeseries, arrayKeyProp}) {
   const [data, setData] = useState([]);
+  const [arrayKey, setArrayKey] = useState(arrayKeyProp);
   const svgRef = useRef();
 
   useEffect(() => {
     setData(timeseries);
   }, [timeseries]);
+
+  useEffect(() => {
+    if (arrayKeyProp) setArrayKey(`daily${arrayKeyProp}`);
+  }, [arrayKeyProp, arrayKey]);
 
   useEffect(() => {
     if (!data.length) return;

--- a/src/components/deltabargraph.js
+++ b/src/components/deltabargraph.js
@@ -24,6 +24,7 @@ function DeltaBarGraph({timeseries, arrayKey}) {
       for (const day of data) {
         if (day[arrayKey] < 0) {
           chartBottom = height - margin.bottom * 2;
+          break;
         }
       }
     }

--- a/src/components/deltabargraph.js
+++ b/src/components/deltabargraph.js
@@ -23,8 +23,15 @@ function DeltaBarGraph({timeseries, arrayKeyProp}) {
 
     const margin = {top: 50, right: 0, bottom: 50, left: 0};
     const chartRight = width - margin.right;
-    const chartBottom = height - margin.bottom;
+    let chartBottom = height - margin.bottom;
     const barRadius = 5;
+    if (arrayKey === 'dailyactive') {
+      for (const day of data) {
+        if (day[arrayKey] < 0) {
+          chartBottom = height - margin.bottom * 2.2;
+        }
+      }
+    }
 
     const formatTime = d3.timeFormat('%e %b');
     const xScale = d3
@@ -39,7 +46,7 @@ function DeltaBarGraph({timeseries, arrayKeyProp}) {
         0,
         Math.max(
           1,
-          d3.max(data, (d) => d[arrayKey])
+          d3.max(data, (d) => Math.abs(d[arrayKey]))
         ),
       ])
       .range([chartBottom, margin.top]); // - barRadius
@@ -89,7 +96,9 @@ function DeltaBarGraph({timeseries, arrayKeyProp}) {
       .attr('text-anchor', 'middle')
       .attr('font-size', '11px')
       .attr('x', (d) => xScale(formatTime(d.date)) + xScale.bandwidth() / 2)
-      .attr('y', (d) => yScale(d[arrayKey]) - 6)
+      .attr('y', (d) =>
+        d[arrayKey] >= 0 ? yScale(d[arrayKey]) - 6 : yScale(d[arrayKey]) + 12
+      )
       .text((d) => d[arrayKey])
       .append('tspan')
       .attr('class', 'percent')

--- a/src/components/deltabargraph.js
+++ b/src/components/deltabargraph.js
@@ -3,7 +3,7 @@ import React, {useEffect, useRef, useState} from 'react';
 
 function DeltaBarGraph({timeseries, arrayKeyProp}) {
   const [data, setData] = useState([]);
-  const [arrayKey, setArrayKey] = useState(arrayKeyProp);
+  const [arrayKey, setArrayKey] = useState(`daily${arrayKeyProp}`);
   const svgRef = useRef();
 
   useEffect(() => {
@@ -12,7 +12,7 @@ function DeltaBarGraph({timeseries, arrayKeyProp}) {
 
   useEffect(() => {
     if (arrayKeyProp) setArrayKey(`daily${arrayKeyProp}`);
-  }, [arrayKeyProp, arrayKey]);
+  }, [arrayKeyProp, setArrayKey]);
 
   useEffect(() => {
     if (!data.length) return;
@@ -122,9 +122,10 @@ function DeltaBarGraph({timeseries, arrayKeyProp}) {
   );
 }
 
-export default React.memo(DeltaBarGraph, () => {
-  return true;
-});
+export default React.memo(DeltaBarGraph);
+// export default React.memo(DeltaBarGraph, () => {
+//   return true;
+// });
 
 function roundedBar(x, y, w, h, r, f) {
   if (!h) return;

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -419,21 +419,24 @@ function State(props) {
                       )}
                   </div>
                   <div className="district-bar-right">
-                    <div
-                      className="happy-sign fadeInUp"
-                      style={{animationDelay: '0.6s'}}
-                    >
-                      {timeseries
-                        .slice(-5)
-                        .every((day) => day.dailyconfirmed === 0) && (
-                        <div className="alert is-green">
-                          <Icon.Smile />
-                          <div className="alert-right">
-                            No new confirmed cases in the past five days
+                    {(mapOption === 'confirmed' ||
+                      mapOption === 'deceased') && (
+                      <div
+                        className="happy-sign fadeInUp"
+                        style={{animationDelay: '0.6s'}}
+                      >
+                        {timeseries
+                          .slice(-5)
+                          .every((day) => day[`daily${mapOption}`] === 0) && (
+                          <div className="alert is-green">
+                            <Icon.Smile />
+                            <div className="alert-right">
+                              No new {mapOption} cases in the past five days
+                            </div>
                           </div>
-                        </div>
-                      )}
-                    </div>
+                        )}
+                      </div>
+                    )}
                     {
                       <DeltaBarGraph
                         timeseries={timeseries.slice(-5)}

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -358,7 +358,6 @@ function State(props) {
                 <div
                   className="district-bar"
                   style={!showAllDistricts ? {display: 'flex'} : {}}
-                  key={mapOption}
                 >
                   <div
                     className="district-bar-left fadeInUp"
@@ -396,8 +395,10 @@ function State(props) {
                                   <h2>{cases[mapOption]}</h2>
                                   <h5>{district}</h5>
                                   <div className="delta">
-                                    <Icon.ArrowUp />
-                                    <h6>{cases.delta[mapOption]}</h6>
+                                    <Icon.ArrowUp className={mapOption} />
+                                    <h6 className={mapOption}>
+                                      {cases.delta[mapOption]}
+                                    </h6>
                                   </div>
                                 </div>
                               );
@@ -434,7 +435,8 @@ function State(props) {
                     {
                       <DeltaBarGraph
                         timeseries={timeseries.slice(-5)}
-                        arrayKey={`daily${mapOption}`}
+                        arrayKeyProp={mapOption}
+                        key={mapOption}
                       />
                     }
                   </div>

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -444,7 +444,7 @@ function State(props) {
                     {
                       <DeltaBarGraph
                         timeseries={timeseries.slice(-5)}
-                        arrayKeyProp={mapOption}
+                        arrayKey={`daily${mapOption}`}
                       />
                     }
                   </div>

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -428,7 +428,11 @@ function State(props) {
                         {timeseries
                           .slice(-5)
                           .every((day) => day[`daily${mapOption}`] === 0) && (
-                          <div className="alert is-green">
+                          <div
+                            className={`alert ${
+                              mapOption === 'confirmed' ? 'is-green' : ''
+                            }`}
+                          >
                             <Icon.Smile />
                             <div className="alert-right">
                               No new {mapOption} cases in the past five days

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -358,12 +358,13 @@ function State(props) {
                 <div
                   className="district-bar"
                   style={!showAllDistricts ? {display: 'flex'} : {}}
+                  key={mapOption}
                 >
                   <div
                     className="district-bar-left fadeInUp"
                     style={{animationDelay: '0.6s'}}
                   >
-                    <h2>Top districts</h2>
+                    <h2 className={mapOption}>Top districts</h2>
                     <div
                       className={`districts ${
                         showAllDistricts ? 'is-grid' : ''
@@ -377,34 +378,26 @@ function State(props) {
                       {districtData[stateName]
                         ? Object.keys(districtData[stateName].districtData)
                             .filter((d) => d !== 'Unknown')
-                            .sort(
-                              (a, b) =>
-                                districtData[stateName].districtData[b]
-                                  .confirmed -
-                                districtData[stateName].districtData[a]
-                                  .confirmed
-                            )
+                            .sort((a, b) => {
+                              const districtB =
+                                districtData[stateName].districtData[b];
+                              const districtA =
+                                districtData[stateName].districtData[a];
+                              return (
+                                districtB[mapOption] - districtA[mapOption]
+                              );
+                            })
                             .slice(0, showAllDistricts ? undefined : 5)
                             .map((district, index) => {
+                              const cases =
+                                districtData[stateName].districtData[district];
                               return (
                                 <div key={index} className="district">
-                                  <h2>
-                                    {
-                                      districtData[stateName].districtData[
-                                        district
-                                      ].confirmed
-                                    }
-                                  </h2>
+                                  <h2>{cases[mapOption]}</h2>
                                   <h5>{district}</h5>
                                   <div className="delta">
                                     <Icon.ArrowUp />
-                                    <h6>
-                                      {
-                                        districtData[stateName].districtData[
-                                          district
-                                        ].delta.confirmed
-                                      }
-                                    </h6>
+                                    <h6>{cases.delta[mapOption]}</h6>
                                   </div>
                                 </div>
                               );
@@ -441,7 +434,7 @@ function State(props) {
                     {
                       <DeltaBarGraph
                         timeseries={timeseries.slice(-5)}
-                        arrayKey={'dailyconfirmed'}
+                        arrayKey={`daily${mapOption}`}
                       />
                     }
                   </div>

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -394,12 +394,14 @@ function State(props) {
                                 <div key={index} className="district">
                                   <h2>{cases[mapOption]}</h2>
                                   <h5>{district}</h5>
-                                  <div className="delta">
-                                    <Icon.ArrowUp className={mapOption} />
-                                    <h6 className={mapOption}>
-                                      {cases.delta[mapOption]}
-                                    </h6>
-                                  </div>
+                                  {mapOption !== 'active' && (
+                                    <div className="delta">
+                                      <Icon.ArrowUp className={mapOption} />
+                                      <h6 className={mapOption}>
+                                        {cases.delta[mapOption]}
+                                      </h6>
+                                    </div>
+                                  )}
                                 </div>
                               );
                             })
@@ -436,7 +438,6 @@ function State(props) {
                       <DeltaBarGraph
                         timeseries={timeseries.slice(-5)}
                         arrayKeyProp={mapOption}
-                        key={mapOption}
                       />
                     }
                   </div>


### PR DESCRIPTION
**Description of PR**
* this PR will allow to switch b/w confirmed, active, recovered and deceased delta bar graph.

**Relevant Issues**  
Fixes #1603 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![desktop act](https://user-images.githubusercontent.com/45959932/80492897-45eaf000-8982-11ea-9006-142b9f832f6f.gif)


![20200428_141654](https://user-images.githubusercontent.com/45959932/80467277-33a98b80-895b-11ea-9047-0905c3eba001.gif)

