### PR TITLE
Feat: add active, recovered, deceased to district table

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -732,7 +732,6 @@ h6 {
 
       .state-last-update {
         background: transparent;
-        transform: translateX(1rem);
 
         &:hover {
           background: #fff !important;
@@ -751,7 +750,6 @@ h6 {
 
       .district-heading {
         background: $gray-light;
-        transform: translateX(1rem);
 
         td {
           background: $gray-light;
@@ -784,10 +782,6 @@ h6 {
             }
           }
         }
-      }
-
-      .district {
-        transform: translateX(1rem);
       }
     }
 
@@ -1642,7 +1636,7 @@ table {
 
       &.spacer {
         background: #fff !important;
-        height: .5rem;
+        height: 2rem;
       }
     }
 
@@ -1696,23 +1690,56 @@ table {
     .state-last-update {
       background: transparent;
       color: $green !important;
-      transform: translateX(1rem);
+      height: 2rem;
 
-      &:hover {
-        background: #fff !important;
+      h6 {
+        margin: 0;
       }
 
-      td {
-        .last-update {
-          align-items: baseline;
-          display: flex;
-          flex-direction: row;
-          text-align: left;
-          width: 100%;
+      &:hover {
+        background: transparent !important;
+      }
 
-          h6 {
-            color: $green !important;
-            font-weight: 600;
+      .disclaimer {
+        backdrop-filter: saturate(180%) blur(20px);
+        background: $gray-light;
+        border-radius: 5px;
+        color: $gray;
+        display: flex;
+        flex-direction: row;
+        font-family: 'archia';
+        font-size: 12px;
+        left: 0;
+        margin-top: .5rem;
+        padding: .5rem;
+        width: 14rem;
+
+        svg {
+          margin-right: .25rem;
+          margin-top: -.25rem;
+          stroke-width: 2px;
+          width: 20px !important;
+        }
+      }
+
+      .state-page-link {
+        padding: 0 !important;
+
+        a {
+          background: $yellow-light;
+          border-radius: 5px;
+          color: $orange;
+          font-size: .75rem;
+          padding: .5rem;
+          text-decoration: none;
+          transition: all .2s ease-in-out;
+
+          &:hover {
+            background: $yellow-hover;
+
+            svg {
+              stroke: $orange;
+            }
           }
         }
       }
@@ -1720,7 +1747,6 @@ table {
 
     .district-heading {
       background: $gray-light;
-      transform: translateX(1rem);
 
       &:hover {
         background: $gray-light !important;
@@ -1755,48 +1781,7 @@ table {
             width: 10px;
           }
         }
-
-        &.state-page-link {
-          background: $white;
-          padding: 0;
-          text-align: left;
-
-          div {
-            align-items: center;
-            background: $yellow-light;
-            border-radius: 5px;
-            color: $orange;
-            float: left;
-            font-size: .75rem;
-            padding: .45rem;
-            transition: all .2s ease-in-out;
-
-            &:hover {
-              background: $yellow-hover;
-
-              svg {
-                stroke: $orange;
-              }
-            }
-
-            svg {
-              color: $orange-mid;
-              height: 12px;
-              margin-bottom: 1px;
-              margin-left: .25rem;
-              stroke-width: 3px;
-              transition: all .2s ease-in-out;
-              vertical-align: middle;
-              width: 12px;
-            }
-          }
-        }
       }
-    }
-
-
-    .district {
-      transform: translateX(1rem);
     }
   }
 
@@ -4772,7 +4757,6 @@ footer {
 
         .state-last-update {
           background: transparent;
-          transform: translateX(1rem);
 
           &:hover {
             background: #fff !important;
@@ -4791,7 +4775,6 @@ footer {
 
         .district-heading {
           background: $gray-light;
-          transform: translateX(1rem);
 
           td {
             background: $gray-light;
@@ -4824,11 +4807,6 @@ footer {
               }
             }
           }
-        }
-
-
-        .district {
-          transform: translateX(1rem);
         }
       }
 

--- a/src/components/row.js
+++ b/src/components/row.js
@@ -52,11 +52,11 @@ function Row(props) {
             const value1 =
               sortColumn === 'district'
                 ? district1
-                : parseInt(aDistricts[district1].confirmed);
+                : parseInt(aDistricts[district1][sortData.sortColumn]);
             const value2 =
               sortColumn === 'district'
                 ? district2
-                : parseInt(aDistricts[district2].confirmed);
+                : parseInt(aDistricts[district2][sortData.sortColumn]);
             const comparisonValue =
               value1 > value2
                 ? 1
@@ -187,25 +187,41 @@ function Row(props) {
 
       {showDistricts && (
         <React.Fragment>
+          <tr
+            className={`spacer`}
+            style={{display: props.reveal && !props.total ? '' : 'none'}}
+          >
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          </tr>
+
           <tr className={'state-last-update'}>
-            <td colSpan={2}>
-              <div className="last-update">
-                <h6>Last updated&nbsp;</h6>
-                <h6
-                  title={
-                    isNaN(Date.parse(formatDate(props.state.lastupdatedtime)))
-                      ? ''
-                      : formatDateAbsolute(props.state.lastupdatedtime)
-                  }
-                >
-                  {isNaN(Date.parse(formatDate(props.state.lastupdatedtime)))
+            <td colSpan={3}>
+              <h6
+                title={
+                  isNaN(Date.parse(formatDate(props.state.lastupdatedtime)))
                     ? ''
-                    : `${formatDistance(
-                        new Date(formatDate(props.state.lastupdatedtime)),
-                        new Date()
-                      )} ago`}
-                </h6>
-              </div>
+                    : formatDateAbsolute(props.state.lastupdatedtime)
+                }
+              >
+                {isNaN(Date.parse(formatDate(props.state.lastupdatedtime)))
+                  ? ''
+                  : `Last updated ${formatDistance(
+                      new Date(formatDate(props.state.lastupdatedtime)),
+                      new Date()
+                    )} ago`}
+              </h6>
+              {sortedDistricts?.Unknown && (
+                <div className="disclaimer">
+                  <Icon.AlertCircle />
+                  {`District-wise numbers are under reconciliation`}
+                </div>
+              )}
+            </td>
+            <td className="state-page-link" colSpan={2}>
+              <Link to={`state/${state.statecode}`}>Visit state page</Link>
             </td>
           </tr>
 
@@ -253,13 +269,85 @@ function Row(props) {
                 </div>
               </div>
             </td>
-            <td className="state-page-link" colSpan={3}>
-              <Link to={`state/${state.statecode}`}>
-                <div>
-                  <abbr>Visit state page</abbr>
-                  <Icon.ArrowRightCircle />
+            <td onClick={(e) => handleSort('active')}>
+              <div className="heading-content">
+                <abbr
+                  className={`${window.innerWidth <= 769 ? 'is-blue' : ''}`}
+                  title="Active"
+                >
+                  {window.innerWidth <= 769
+                    ? window.innerWidth <= 375
+                      ? 'A'
+                      : 'Actv'
+                    : 'Active'}
+                </abbr>
+                <div
+                  style={{
+                    display:
+                      sortData.sortColumn === 'active' ? 'initial' : 'none',
+                  }}
+                >
+                  {sortData.isAscending ? (
+                    <div className="arrow-up" />
+                  ) : (
+                    <div className="arrow-down" />
+                  )}
                 </div>
-              </Link>
+              </div>
+            </td>
+            <td onClick={(e) => handleSort('recovered')}>
+              <div className="heading-content">
+                <abbr
+                  className={`${window.innerWidth <= 769 ? 'is-green' : ''}`}
+                  title="Recovered"
+                >
+                  {window.innerWidth <= 769
+                    ? window.innerWidth <= 375
+                      ? 'R'
+                      : 'Rcvrd'
+                    : 'Recovered'}
+                </abbr>
+                <div
+                  style={{
+                    display:
+                      sortData.sortColumn === 'recovered'
+                        ? 'sort-black'
+                        : 'none',
+                  }}
+                >
+                  {sortData.isAscending ? (
+                    <div className="arrow-up" />
+                  ) : (
+                    <div className="arrow-down" />
+                  )}
+                </div>
+              </div>
+            </td>
+            <td onClick={(e) => handleSort('deceased')}>
+              <div className="heading-content">
+                <abbr
+                  className={`${window.innerWidth <= 769 ? 'is-gray' : ''}`}
+                  title="Deaths"
+                >
+                  {window.innerWidth <= 769
+                    ? window.innerWidth <= 375
+                      ? 'D'
+                      : 'Dcsd'
+                    : 'Deceased'}
+                </abbr>
+                <div
+                  style={{
+                    display:
+                      sortData.sortColumn === 'deceased' ? 'initial' : 'none',
+                  }}
+                >
+                  {sortData.isAscending ? (
+                    <div className="arrow-up" />
+                  ) : (
+                    <div className="arrow-down" />
+                  )}
+                </div>
+              </div>
             </td>
           </tr>
         </React.Fragment>
@@ -313,6 +401,33 @@ function Row(props) {
                       {formatNumber(sortedDistricts[district].confirmed)}
                     </span>
                   </td>
+                  <td>{formatNumber(sortedDistricts[district].active)}</td>
+                  <td>
+                    <span className="deltas" style={{color: '#28a745'}}>
+                      {sortedDistricts[district].delta.recovered > 0 && (
+                        <Icon.ArrowUp />
+                      )}
+                      {sortedDistricts[district].delta.recovered > 0
+                        ? `${sortedDistricts[district].delta.recovered}`
+                        : ''}
+                    </span>
+                    <span className="table__count-text">
+                      {formatNumber(sortedDistricts[district].recovered)}
+                    </span>
+                  </td>
+                  <td>
+                    <span className="deltas" style={{color: '#6c757d'}}>
+                      {sortedDistricts[district].delta.deceased > 0 && (
+                        <Icon.ArrowUp />
+                      )}
+                      {sortedDistricts[district].delta.deceased > 0
+                        ? `${sortedDistricts[district].delta.deceased}`
+                        : ''}
+                    </span>
+                    <span className="table__count-text">
+                      {formatNumber(sortedDistricts[district].deceased)}
+                    </span>
+                  </td>
                 </tr>
               );
             }
@@ -350,6 +465,33 @@ function Row(props) {
                 {formatNumber(sortedDistricts['Unknown'].confirmed)}
               </span>
             </td>
+            <td>{formatNumber(sortedDistricts['Unknown'].active)}</td>
+            <td>
+              <span className="deltas" style={{color: '#28a745'}}>
+                {sortedDistricts['Unknown'].delta.recovered > 0 && (
+                  <Icon.ArrowUp />
+                )}
+                {sortedDistricts['Unknown'].delta.recovered > 0
+                  ? `${sortedDistricts['Unknown'].delta.recovered}`
+                  : ''}
+              </span>
+              <span className="table__count-text">
+                {formatNumber(sortedDistricts['Unknown'].recovered)}
+              </span>
+            </td>
+            <td>
+              <span className="deltas" style={{color: '#6c757d'}}>
+                {sortedDistricts['Unknown'].delta.deceased > 0 && (
+                  <Icon.ArrowUp />
+                )}
+                {sortedDistricts['Unknown'].delta.deceased > 0
+                  ? `${sortedDistricts['Unknown'].delta.deceased}`
+                  : ''}
+              </span>
+              <span className="table__count-text">
+                {formatNumber(sortedDistricts['Unknown'].deceased)}
+              </span>
+            </td>
           </tr>
         </React.Fragment>
       )}
@@ -357,18 +499,16 @@ function Row(props) {
       {showDistricts && (
         <React.Fragment>
           <tr>
-            <td colSpan={2}>
-              <span className="unknown">
-                <ReactTooltip
-                  id="unknown"
-                  place="right"
-                  type="dark"
-                  effect="solid"
-                  multiline={true}
-                  scrollHide={true}
-                  globalEventOff="click"
-                />
-              </span>
+            <td colSpan={5}>
+              <ReactTooltip
+                id="unknown"
+                place="right"
+                type="dark"
+                effect="solid"
+                multiline={true}
+                scrollHide={true}
+                globalEventOff="click"
+              />
             </td>
           </tr>
         </React.Fragment>
@@ -378,6 +518,7 @@ function Row(props) {
         className={`spacer`}
         style={{display: props.reveal && !props.total ? '' : 'none'}}
       >
+        <td></td>
         <td></td>
         <td></td>
         <td></td>


### PR DESCRIPTION
Add columns for active recovered and deceased numbers for districts in the home page table.

**Relevant Issues**  
Fixes #1607 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

![2020-04-28 23 20 30](https://user-images.githubusercontent.com/17372422/80520855-ae989380-89a7-11ea-8117-16e29009a9a8.jpg)
<img width="1279" alt="Screenshot 2020-04-28 at 11 23 23 PM" src="https://user-images.githubusercontent.com/17372422/80520593-4a75cf80-89a7-11ea-966a-588ac064764a.png">



