### PR TITLE
Style: Gap in case of states with nil testcase

### DIFF
--- a/src/components/state.js
+++ b/src/components/state.js
@@ -194,19 +194,23 @@ function State(props) {
                 <h5 className="timestamp">
                   {!isNaN(
                     parse(testObjLast?.updatedon, 'dd/MM/yyyy', new Date())
-                  )
-                    ? `As of ${format(
-                        parse(testObjLast?.updatedon, 'dd/MM/yyyy', new Date()),
-                        'dd MMM'
-                      )}`
-                    : ''}
+                  ) ? (
+                    `As of ${format(
+                      parse(testObjLast?.updatedon, 'dd/MM/yyyy', new Date()),
+                      'dd MMM'
+                    )}`
+                  ) : (
+                    <div style={{height: '30px'}}></div>
+                  )}
                 </h5>
                 <h5>
-                  {'per '}
                   {testObjLast?.totaltested && (
-                    <a href={testObjLast.source} target="_noblank">
-                      source
-                    </a>
+                    <span>
+                      {'per '}
+                      <a href={testObjLast.source} target="_noblank">
+                        source
+                      </a>
+                    </span>
                   )}
                 </h5>
               </div>


### PR DESCRIPTION
**Description of PR**
- Added gap between confirmed, active etc. headers and top border of colored boxes.
- Removed 'per' when there is no testcases.


**Relevant Issues**  
Fixes #1718

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
### Before
![Screenshot (68)_LI](https://user-images.githubusercontent.com/11428805/80866078-7ac0b500-8caa-11ea-9e73-270c79ae3245.jpg)

### After
![Screenshot (70)](https://user-images.githubusercontent.com/11428805/80866062-58c73280-8caa-11ea-8cfc-f33418f91651.png)
