### PR TITLE
Style: Disable MapExplorer Hyperlink In State Page

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -486,6 +486,7 @@ h6 {
     a {
       pointer-events: none;
       cursor: default;
+      touch-action: none;
     }
 
     .svg-parent {

--- a/src/App.scss
+++ b/src/App.scss
@@ -483,6 +483,11 @@ h6 {
       display: none;
     }
 
+    a {
+      pointer-events: none;
+      cursor: default;
+    }
+
     .svg-parent {
       &:not(.legend) {
         height: 400px;


### PR DESCRIPTION
**Description of PR**

Currently, in State pages, even though  back button is disabled, a hidden hyperlink is present,as a result of reuse of map components,  which takes user back to Home Page. Disabled the hidden hyperlink through CSS change , so that redirection occurs only from breadcrumbs on top of page.

**Relevant Issues**  
Fixes #1681

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

![chrome](https://user-images.githubusercontent.com/27771780/80870959-6fc84d80-8cc7-11ea-8701-86cf641d8070.png)
Chrome

![responsive](https://user-images.githubusercontent.com/27771780/80871003-b453e900-8cc7-11ea-9e61-7da648a5643a.png)
Responsive

![mozilla](https://user-images.githubusercontent.com/27771780/80871041-e9603b80-8cc7-11ea-8a50-cce8fcfaebef.png)
Mozilla

