### PR TITLE
Closes patient modal by escape button

### DIFF
--- a/src/components/patients.js
+++ b/src/components/patients.js
@@ -3,7 +3,7 @@ import PatientsView from './patientsview';
 import {parse} from 'date-fns';
 import React, {useState, useEffect, useCallback} from 'react';
 import * as Icon from 'react-feather';
-import {useLockBodyScroll} from 'react-use';
+import {useLockBodyScroll, useKeyPressEvent} from 'react-use';
 
 function Patients(props) {
   const [patients, setPatients] = useState(props.patients);
@@ -19,6 +19,10 @@ function Patients(props) {
       setModal(false);
     }
   };
+
+  useKeyPressEvent('Escape', () => {
+    setModal(false);
+  });
 
   useEffect(() => {
     setPatients(props.patients);


### PR DESCRIPTION
**Description of PR**

Patient information modals will close on the Escape button press.

**Relevant Issues**  
Fixes #1738 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone
