### PR TITLE
Add string comparison logic for state name sorting

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -110,9 +110,17 @@ function Table({
   const doSort = useCallback(
     (sortData) => {
       const newSortedStates = [...sortedStates].sort((x, y) => {
-        return sortData.isAscending
-          ? parseInt(x[sortData.sortColumn]) - parseInt(y[sortData.sortColumn])
-          : parseInt(y[sortData.sortColumn]) - parseInt(x[sortData.sortColumn]);
+        if (sortData.sortColumn !== 'state') {
+          return sortData.isAscending
+            ? parseInt(x[sortData.sortColumn]) -
+                parseInt(y[sortData.sortColumn])
+            : parseInt(y[sortData.sortColumn]) -
+                parseInt(x[sortData.sortColumn]);
+        } else {
+          return sortData.isAscending
+            ? x[sortData.sortColumn].localeCompare(y[sortData.sortColumn])
+            : y[sortData.sortColumn].localeCompare(x[sortData.sortColumn]);
+        }
       });
       setSortedStates(newSortedStates);
     },


### PR DESCRIPTION
**Description of PR**
String comparison for state names was missing. Which is now added.

**Relevant Issues**  
Fixes #1747 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone
