### PR TITLE
Fix: disable expand switch when there is no cases

### DIFF
--- a/src/components/patientdb.js
+++ b/src/components/patientdb.js
@@ -341,11 +341,16 @@ function PatientDB(props) {
         <div>
           <h1>Demographics</h1>
 
-          <div className="deep-dive">
+          <div
+            className={`deep-dive ${
+              message || filteredPatients.length === 0 ? 'disabled' : ''
+            }`}
+          >
             <h5>Expand</h5>
             <input
               type="checkbox"
               checked={scaleMode}
+              disabled={message || filteredPatients.length === 0}
               onChange={(event) => {
                 setScaleMode(!scaleMode);
               }}


### PR DESCRIPTION
**Description of PR**
* this PR will fix active of expand switch even when there is no patients case on particular date of State/UT/district/city.

**Relevant Issues**  
Fixes #1753 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![fix act](https://user-images.githubusercontent.com/45959932/80925373-e55a1980-8dac-11ea-86a7-ef4497c58a79.gif)
