### PR TITLE
[Fix]: Fixed table content overflow for mobile browser

### DIFF
--- a/src/utils/commonfunctions.js
+++ b/src/utils/commonfunctions.js
@@ -97,7 +97,11 @@ export function sliceTimeseriesFromEnd(timeseries, days) {
 
 export const formatNumber = (value) => {
   const numberFormatter = new Intl.NumberFormat('en-IN');
-  return isNaN(value) ? '-' : numberFormatter.format(value);
+  if (isNaN(value)) return '-';
+  if (window.innerWidth <= 375) {
+    return Math.abs(value) > 999 ? Math.sign(value) * ((Math.abs(value) / 1000).toFixed(1)) + 'k' : Math.sign(value) * Math.abs(value)
+  }
+  else return numberFormatter.format(value)
 };
 
 export const parseStateTimeseries = ({states_daily: data}) => {

--- a/src/utils/commonfunctions.js
+++ b/src/utils/commonfunctions.js
@@ -99,9 +99,16 @@ export const formatNumber = (value) => {
   const numberFormatter = new Intl.NumberFormat('en-IN');
   if (isNaN(value)) return '-';
   if (window.innerWidth <= 375) {
-    return Math.abs(value) > 999 ? Math.sign(value) * ((Math.abs(value) / 1000).toFixed(1)) + 'k' : Math.sign(value) * Math.abs(value)
-  }
-  else return numberFormatter.format(value)
+    return Math.abs(Number(value)) >= 1.0e9
+      ? (Math.abs(Number(value)) / 1.0e9).toFixed(1) + 'B'
+      : // Six Zeroes for Millions
+      Math.abs(Number(value)) >= 1.0e6
+      ? (Math.abs(Number(value)) / 1.0e6).toFixed(1) + 'M'
+      : // Three Zeroes for Thousands
+      Math.abs(Number(value)) >= 1.0e3
+      ? (Math.abs(Number(value)) / 1.0e3).toFixed(1) + 'k'
+      : Math.abs(Number(value));
+  } else return numberFormatter.format(value);
 };
 
 export const parseStateTimeseries = ({states_daily: data}) => {


### PR DESCRIPTION
**Description of PR**

For viewing on mobile devices with width <= 375, the number of cases greater than 1,000 will be visible as a number times k.
Example:

- 5,428 is visible as 5.4k
- 1.4M Tested

**Relevant Issues**  
Fixes #1745 

**Checklist**

 - [x] Compiles and passes lint tests
 - [x] Properly formatted
 - [x] Tested on desktop
 - [x] Tested on phone

**Screenshots**

![ss](https://user-images.githubusercontent.com/47109189/80926468-1a6a6a00-8db5-11ea-947e-ec99e1a6b8b6.png)

