### PR TITLE
Fix: view {state} page link inside table occupying full tr bg(inconsistency)

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2065,11 +2065,13 @@ table {
 
       .state-page-link {
         background: $yellow-light !important;
+        border-radius: 5px;
         color: $orange;
         font-size: .75rem;
         font-weight: 600;
         padding: .5rem;
         text-align: center;
+        transition: .2s all ease-in-out;
 
         &:hover {
           background: $yellow-hover !important;

--- a/src/components/row.js
+++ b/src/components/row.js
@@ -317,13 +317,16 @@ function Row({
               )}
             </td>
             <td
-              align="center"
-              className="state-page-link"
+              style={{verticalAlign: 'bottom'}}
               colSpan={2}
               onClick={() => {
                 history.push(`state/${state.statecode}`);
               }}
-            >{`View ${t(state.state)}'s Page`}</td>
+            >
+              <div className="state-page-link">{`View ${t(
+                state.state
+              )}'s Page`}</div>
+            </td>
           </tr>
 
           <tr className={classnames('district-heading')}>


### PR DESCRIPTION
**Description of PR**
*  view {state} page link inside table occupying full tr height bg leads to inconsistency with other state link.

**Relevant Issues**  
Fixes #1794 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Screenshot from 2020-05-06 01-56-59](https://user-images.githubusercontent.com/45959932/81112850-ecb02d00-8f3c-11ea-8e07-d163b829becb.png)
![Screenshot from 2020-05-06 01-57-07](https://user-images.githubusercontent.com/45959932/81112862-efab1d80-8f3c-11ea-8256-59ccdbc86573.png)
