### PR TITLE
[Fix]: Made MiniGraph style compatible with edge by changing rgba hexcode to

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",
-      "last 1 safari version"
+      "last 1 safari version",
+      "last 1 ie version"
     ]
   }
 }

--- a/src/components/minigraph.js
+++ b/src/components/minigraph.js
@@ -61,7 +61,7 @@ function Minigraph({timeseries}) {
         .append('path')
         .datum(data)
         .attr('fill', 'none')
-        .attr('stroke', color + '99')
+        .attr('stroke', color)
         .attr('stroke-width', 2.5)
         .attr('cursor', 'pointer')
         .attr(
@@ -71,7 +71,8 @@ function Minigraph({timeseries}) {
             .x((d) => xScale(d.date))
             .y((d) => yScale(d[type]))
             .curve(d3.curveCardinal)
-        );
+        )
+        .style('opacity', 0.6);
 
       const totalLength = path.node().getTotalLength();
       path


### PR DESCRIPTION
rgb hexcode and opacity styling

**Description of PR**

issue #1716, path of MiniGraph was not appearing in Microsoft Edge. 

**Relevant Issues**  
Fixes #...
The issue is solved by removing the color attribute of path from rgba hexcode to rgb hexcode and opacity is set to 0.6(which was previousy 99(hex)/ff converted to 0.6/1) as a style.

**Checklist**

- [1 ] Compiles and passes lint tests
- [ 1] Properly formatted
- [ 1] Tested on desktop
- [ 0] Tested on phone

**Screenshots**
![image](https://user-images.githubusercontent.com/36895341/81171022-4e15e180-8fb9-11ea-8d0f-3672a94789ea.png)

