### PR TITLE
Fix: Timeseries aligned center in homepage for mobile devices

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2689,6 +2689,7 @@ table {
 
 .TimeSeriesExplorer {
   align-self: center;
+  margin: 0 auto;
   width: 30rem;
 
   &.stickied {

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -237,25 +237,23 @@ function Home(props) {
                 setIsTimeseriesIntersecting(isIntersecting)
               }
             >
-              <div>
-                {timeseries && (
-                  <TimeSeriesExplorer
-                    timeseries={
-                      timeseries[
-                        STATE_CODES_REVERSE[regionHighlighted?.state] || 'TT'
-                      ]
-                    }
-                    activeStateCode={
+              {timeseries && (
+                <TimeSeriesExplorer
+                  timeseries={
+                    timeseries[
                       STATE_CODES_REVERSE[regionHighlighted?.state] || 'TT'
-                    }
-                    onHighlightState={onHighlightState}
-                    states={states}
-                    anchor={anchor}
-                    setAnchor={setAnchor}
-                    isIntersecting={isTimeseriesIntersecting}
-                  />
-                )}
-              </div>
+                    ]
+                  }
+                  activeStateCode={
+                    STATE_CODES_REVERSE[regionHighlighted?.state] || 'TT'
+                  }
+                  onHighlightState={onHighlightState}
+                  states={states}
+                  anchor={anchor}
+                  setAnchor={setAnchor}
+                  isIntersecting={isTimeseriesIntersecting}
+                />
+              )}
             </Observer>
           </React.Fragment>
         </div>

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -237,23 +237,25 @@ function Home(props) {
                 setIsTimeseriesIntersecting(isIntersecting)
               }
             >
-              {timeseries && (
-                <TimeSeriesExplorer
-                  timeseries={
-                    timeseries[
+              <div>
+                {timeseries && (
+                  <TimeSeriesExplorer
+                    timeseries={
+                      timeseries[
+                        STATE_CODES_REVERSE[regionHighlighted?.state] || 'TT'
+                      ]
+                    }
+                    activeStateCode={
                       STATE_CODES_REVERSE[regionHighlighted?.state] || 'TT'
-                    ]
-                  }
-                  activeStateCode={
-                    STATE_CODES_REVERSE[regionHighlighted?.state] || 'TT'
-                  }
-                  onHighlightState={onHighlightState}
-                  states={states}
-                  anchor={anchor}
-                  setAnchor={setAnchor}
-                  isIntersecting={isTimeseriesIntersecting}
-                />
-              )}
+                    }
+                    onHighlightState={onHighlightState}
+                    states={states}
+                    anchor={anchor}
+                    setAnchor={setAnchor}
+                    isIntersecting={isTimeseriesIntersecting}
+                  />
+                )}
+              </div>
             </Observer>
           </React.Fragment>
         </div>


### PR DESCRIPTION
**Description of PR**
Timeseries is aligned center in homepage for mobile devices by making css changes. Before it was towards left side.

**Relevant Issues**  
Fixes #1807 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
### before
![Screenshot_20200507-173453](https://user-images.githubusercontent.com/11428805/81292434-39a11a00-9089-11ea-9cec-a50c5c0fae38.jpg)

### after
![Screenshot_20200507-173436](https://user-images.githubusercontent.com/11428805/81292445-3efe6480-9089-11ea-8025-8abff4cf5ada.jpg)
