### PR TITLE
added reponsive text size on Level component

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -75,7 +75,7 @@ body {
 
 h1 {
   font-family: 'archia';
-  font-size: 24px !important;
+  font-size: 24px ;
   font-weight: 900;
 }
 

--- a/src/components/level.js
+++ b/src/components/level.js
@@ -80,7 +80,7 @@ function Level(props) {
           className="title has-text-success"
           style={{fontSize: getFontSize(formatNumber(data.recovered))}}
         >
-          {formatNumber(data.recovered)}
+          {formatNumber(data.recovered)}{' '}
         </h1>
       </div>
 

--- a/src/components/level.js
+++ b/src/components/level.js
@@ -4,6 +4,14 @@ import React, {useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {useEffectOnce} from 'react-use';
 
+function getFontSize(number) {
+  console.log(number);
+  if (number.length <= 4) {
+    return 24;
+  }
+  return 24 - number.length + 3;
+}
+
 function Level(props) {
   const [data, setData] = useState(props.data);
   const {t} = useTranslation();
@@ -36,7 +44,9 @@ function Level(props) {
             : '+0'}
           ]
         </h4>
-        <h1>{formatNumber(data.confirmed)} </h1>
+        <h1 style={{fontSize: getFontSize(formatNumber(data.confirmed))}}>
+          {formatNumber(data.confirmed)}{' '}
+        </h1>
       </div>
 
       <div
@@ -45,7 +55,12 @@ function Level(props) {
       >
         <h5 className="heading">{t('Active')}</h5>
         <h4>&nbsp;</h4>
-        <h1 className="title has-text-info">{formatNumber(data.active)}</h1>
+        <h1
+          className="title has-text-info"
+          style={{fontSize: getFontSize(formatNumber(data.active))}}
+        >
+          {formatNumber(data.active)}
+        </h1>
       </div>
 
       <div
@@ -62,8 +77,11 @@ function Level(props) {
             : '+0'}
           ]
         </h4>
-        <h1 className="title has-text-success">
-          {formatNumber(data.recovered)}{' '}
+        <h1
+          className="title has-text-success"
+          style={{fontSize: getFontSize(formatNumber(data.recovered))}}
+        >
+          {formatNumber(data.recovered)}
         </h1>
       </div>
 
@@ -81,7 +99,12 @@ function Level(props) {
             : '+0'}
           ]
         </h4>
-        <h1 className="title has-text-grey">{formatNumber(data.deaths)}</h1>
+        <h1
+          className="title has-text-grey"
+          style={{fontSize: getFontSize(formatNumber(data.deaths))}}
+        >
+          {formatNumber(data.deaths)}
+        </h1>
       </div>
     </div>
   );

--- a/src/components/level.js
+++ b/src/components/level.js
@@ -5,7 +5,6 @@ import {useTranslation} from 'react-i18next';
 import {useEffectOnce} from 'react-use';
 
 function getFontSize(number) {
-  console.log(number);
   if (number.length <= 4) {
     return 24;
   }


### PR DESCRIPTION
**FONT SIZE VARYING WITH LENGTH OF NUMBER**

Fixed crumbled appearance of text in Level component when large numbers appear on smaller devices. Wrote a function which returns font size according to length of number.

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

**before**

![before](https://user-images.githubusercontent.com/36514842/81294276-45421000-908c-11ea-998c-d6e914c5b2a8.jpeg)

**after**

![after](https://user-images.githubusercontent.com/36514842/81294296-4bd08780-908c-11ea-8c58-e6b8c14be8c2.jpeg)

