### PR TITLE
Tree shake primer components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1826,30 +1826,43 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@primer/components": {
-      "version": "18.1.1",
-      "resolved": "https://registry.npmjs.org/@primer/components/-/components-18.1.1.tgz",
-      "integrity": "sha512-uwge9g/Y8U4F3AonLJwAid/+cyi2/MQP+Hq/g2INY0IhAnwDWPdbIjHD1zIYTbK7WLw/xFCq0gA6l+qiwd4rrg==",
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/@primer/components/-/components-19.0.0.tgz",
+      "integrity": "sha512-aWrO/ueicgCry3Uphbr4N+P9a5m9D6OyDwPvmF8BGLBWCJCplU7QhcWYdCqPqJX8FmmvuZv70EOUD8SmTHM4ww==",
       "requires": {
-        "@primer/octicons-react": "^9.2.0",
+        "@babel/helpers": "7.9.2",
+        "@babel/runtime": "7.9.2",
+        "@primer/octicons-react": "^9.6.0",
         "@primer/primitives": "3.0.0",
         "@reach/dialog": "0.3.0",
+        "@styled-system/css": "5.1.5",
         "@styled-system/prop-types": "5.1.2",
         "@styled-system/props": "5.1.4",
         "@styled-system/theme-get": "5.1.2",
         "@testing-library/react": "9.4.0",
         "@types/styled-components": "^4.4.0",
         "@types/styled-system": "5.1.2",
-        "babel-plugin-macros": "2.6.1",
+        "babel-plugin-macros": "2.8.0",
         "babel-polyfill": "6.26.0",
         "classnames": "^2.2.5",
         "details-element-polyfill": "2.4.0",
         "jest-axe": "3.2.0",
-        "nanoid": "2.1.4",
+        "polished": "3.5.2",
         "react": "^16.10.2",
         "react-is": "16.10.2",
         "styled-system": "5.1.2"
       },
       "dependencies": {
+        "@babel/helpers": {
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+          "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+          "requires": {
+            "@babel/template": "^7.8.3",
+            "@babel/traverse": "^7.9.0",
+            "@babel/types": "^7.9.0"
+          }
+        },
         "@testing-library/react": {
           "version": "9.4.0",
           "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.4.0.tgz",
@@ -2794,9 +2807,9 @@
       }
     },
     "@types/react-native": {
-      "version": "0.62.5",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.62.5.tgz",
-      "integrity": "sha512-x6ZBbo752yAw5XUarOyh53oNgMuafL4EhWEbd4ARSMK6Y7nTRm2a1tBHy8Fp7h7ji0XXJrxNRTXGJRRP3+MWzg==",
+      "version": "0.62.7",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.62.7.tgz",
+      "integrity": "sha512-FGFEt9GcFVl//XxWmxkeBxAx0YnzyEhJpR8hOJrjfaFKZm0KjHzzyCmCksBAP2qHSTrcJCiBkIvYCX/kGiOgww==",
       "requires": {
         "@types/react": "*"
       }
@@ -3817,13 +3830,57 @@
       }
     },
     "babel-plugin-macros": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz",
-      "integrity": "sha512-6W2nwiXme6j1n2erPOnmRiWfObUhWH7Qw1LMi9XZy8cj+KtESu3T6asZvtk5bMQQjX8te35o7CFueiSdL/2NmQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
       "requires": {
-        "@babel/runtime": "^7.4.2",
-        "cosmiconfig": "^5.2.0",
-        "resolve": "^1.10.0"
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+        }
       }
     },
     "babel-plugin-named-asset-import": {
@@ -13225,11 +13282,6 @@
         "stylis": "3.5.0"
       }
     },
-    "nanoid": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.4.tgz",
-      "integrity": "sha512-PijW88Ry+swMFfArOrm7uRAdVmJilLbej7WwVY6L5QwLDckqxSOinGGMV596yp5C8+MH3VvCXCSZ6AodGtKrYQ=="
-    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -14142,6 +14194,14 @@
       "integrity": "sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==",
       "requires": {
         "ts-pnp": "^1.1.6"
+      }
+    },
+    "polished": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.5.2.tgz",
+      "integrity": "sha512-vWoRDg3gY5RQBtUfcj9MRN10VCIf4EkdUikGxyXItg2Hnwk+eIVtdBiLajN0ldFeT3Vq4r/QNbjrQdhqBKrTug==",
+      "requires": {
+        "@babel/runtime": "^7.8.7"
       }
     },
     "popper.js": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@juggle/resize-observer": "^3.1.3",
     "@material-ui/core": "^4.9.12",
-    "@primer/components": "^18.1.1",
+    "@primer/components": "^19.0.0",
     "@researchgate/react-intersection-observer": "^1.1.3",
     "@testing-library/jest-dom": "^5.5.0",
     "@testing-library/react": "^10.0.4",

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -17,7 +17,9 @@ import {
   parseDistrictZones,
 } from '../utils/commonfunctions';
 
-import {Breadcrumb, Dropdown} from '@primer/components';
+import Dropdown from '@primer/components/lib/Dropdown';
+import Breadcrumb from '@primer/components/lib/Breadcrumb';
+
 import anime from 'animejs';
 import axios from 'axios';
 import {format, parse} from 'date-fns';


### PR DESCRIPTION
Not sure how to exactly check if the tree shaking worked but I ran `npm run build` before and after and the bundle size seem to have reduced. Here are the relevant screenshots of `npm run analyze` command for both builds.  Also, the total size of build folder reduced from 11.2mb to 10.7mb

**Before**
![image](https://user-images.githubusercontent.com/31539366/81439247-b9afa880-918b-11ea-9cee-07983adcd540.png)

**After**
![image](https://user-images.githubusercontent.com/31539366/81439287-c92ef180-918b-11ea-91a7-21fe70d1c0f5.png)


**Relevant Issues**  
Fixes #1648 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Add relevant screenshots here

![image](https://user-images.githubusercontent.com/31539366/81439563-2fb40f80-918c-11ea-8fc4-2de08deb7539.png)

