### PR TITLE
Use of ceil() function for Recovered/Deceased patients per 100 . 

### DIFF
--- a/src/components/statemeta.js
+++ b/src/components/statemeta.js
@@ -105,8 +105,8 @@ function StateMeta({
           statistic={`${recoveryPercent.toFixed(2)}%`}
           formula={'(recovered / confirmed) * 100'}
           description={`For every 100 confirmed cases, 
-            ${Math.round(
-              recoveryPercent.toFixed(0)
+            ${Math.ceil(
+              recoveryPercent.toFixed(2)
             )} have recovered from the virus.`}
         />
 
@@ -116,8 +116,8 @@ function StateMeta({
           statistic={`${deathPercent.toFixed(2)}%`}
           formula={'(deceased / confirmed) * 100'}
           description={`For every 100 confirmed cases, 
-            ${Math.round(
-              deathPercent.toFixed(0)
+            ${Math.ceil(
+              deathPercent.toFixed(2)
             )} have unfortunately passed away from the virus.`}
         />
 


### PR DESCRIPTION
**Description of PR**

Use of ceil() instead of round() function for Recovered/Deceased patients per 100 patients. Reasons stated in the issue linked below. 

**Relevant Issues**  
Fixes https://github.com/covid19india/covid19india-react/issues/1885#issue-618124415

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Before
![2020-05-14_LI](https://user-images.githubusercontent.com/42859178/81950451-910f2f00-9621-11ea-837e-02573e4b6fe0.jpg)

After
![2020-05-14 (1)_LI](https://user-images.githubusercontent.com/42859178/81950460-940a1f80-9621-11ea-836e-22f1f597b1a8.jpg)

