### PR TITLE
Fix: label button issues on tap in mobile devices

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -908,9 +908,11 @@ h6 {
     }
   }
 
-  &:hover {
-    background: $yellow-light !important;
-    color: $orange-mid !important;
+  @media not all and (pointer: coarse) {
+    &:hover {
+      background: $yellow-light !important;
+      color: $orange-mid !important;
+    }
   }
 
   .counter {


### PR DESCRIPTION
**Description of PR**
The PR fixes the bug happening when hover interferes with touch on label buttons in mobile devices in essentials page.
It is fixed by allowing hover only on non-touch devices when unselected.

**Relevant Issues**  
Fixes #1907 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
### Before
![ezgif com-video-to-gif (11)](https://user-images.githubusercontent.com/11428805/82121088-289e8a00-97a8-11ea-9673-b5b8eb155205.gif)
### After
![ezgif com-video-to-gif (12)](https://user-images.githubusercontent.com/11428805/82121209-e0cc3280-97a8-11ea-8a2b-be070ffc45cf.gif)
