### PR TITLE
Feature: Use Indian number system for yAxis all Graphs

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -5,6 +5,7 @@ import {
   formatNumber,
   formatTimeseriesDate,
   formatTimeseriesTickX,
+  indianNumberSystemTickFormat,
 } from '../utils/commonfunctions';
 import {useResizeObserver} from '../utils/hooks';
 
@@ -124,10 +125,17 @@ function TimeSeries({timeseriesProp, chartType, mode, logMode, stateCode}) {
         else g.select('.domain').attr('opacity', 0);
       };
 
-      const yAxis = (g, yScale) =>
-        g
+      const yAxis = (g, yScale) => {
+        return g
           .attr('class', 'y-axis')
-          .call(d3.axisRight(yScale).ticks(4, '0~s').tickPadding(5));
+          .call(
+            d3
+              .axisRight(yScale)
+              .ticks(4)
+              .tickFormat(indianNumberSystemTickFormat)
+              .tickPadding(5)
+          );
+      };
 
       // Arrays of objects
       const plotTotal = chartType === 1;

--- a/src/utils/commonfunctions.js
+++ b/src/utils/commonfunctions.js
@@ -301,9 +301,9 @@ export const toTitleCase = (str) => {
 };
 
 export const indianNumberSystemTickFormat = (numberValue) => {
-  const limits = [100000000000, 1000000000, 10000000, 100000, 1000];
-  // Kharab, Arab, Crore, Lakh, Thousand
-  const shorteners = ['K', 'A', 'C', 'L', 'K'];
+  const limits = [1000000000, 10000000, 100000, 1000];
+  // Arab, Crore, Lakh, Thousand
+  const shorteners = ['A', 'Cr', 'L', 'K'];
   for (const i in limits) {
     if (numberValue >= limits[i]) {
       return (numberValue / limits[i]).toFixed() + shorteners[i];

--- a/src/utils/commonfunctions.js
+++ b/src/utils/commonfunctions.js
@@ -299,3 +299,15 @@ export const toTitleCase = (str) => {
     return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
   });
 };
+
+export const indianNumberSystemTickFormat = (numberValue) => {
+  const limits = [100000000000, 1000000000, 10000000, 100000, 1000];
+  // Kharab, Arab, Crore, Lakh, Thousand
+  const shorteners = ['K', 'A', 'C', 'L', 'K'];
+  for (const i in limits) {
+    if (numberValue >= limits[i]) {
+      return (numberValue / limits[i]).toFixed() + shorteners[i];
+    }
+  }
+  return numberValue;
+};


### PR DESCRIPTION
**Description of PR**

Data in the Graph uses Indian Numbering already, yAxis is using SI Numbering System, ie. 10Lakhs is represented as 1Million.

This PR Standardises the yAxis to use the Indian Numbering System.

**Relevant Issues**  
Fixes #1787 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Add relevant screenshots here
**Before**
![Issue](https://user-images.githubusercontent.com/7705367/82151653-20af1a80-987a-11ea-896b-cb05f661915f.gif)

**After**
![After](https://user-images.githubusercontent.com/7705367/82151823-2b1de400-987b-11ea-972f-5d7e1f616b37.gif)