### PR TITLE
Updated Ovellaping Problem of Labels in State Growth Trend Graph of D…

### DIFF
--- a/src/components/Charts/growthtrendchart.js
+++ b/src/components/Charts/growthtrendchart.js
@@ -2,7 +2,7 @@ import {getStateName} from '../../utils/commonfunctions';
 
 import {parse} from 'date-fns';
 import React from 'react';
-import {Line, defaults} from 'react-chartjs-2';
+import {Line,defaults,Bar} from 'react-chartjs-2';
 
 function GrowthTrendChart(props) {
   const dates = [];
@@ -148,26 +148,35 @@ function GrowthTrendChart(props) {
         radius: 0,
       },
       line: {
-        cubicInterpolationMode: 'monotone',
+        cubicInterpolationMode: 'default',
       },
     },
     layout: {
       padding: {
         left: 20,
         right: 20,
-        top: 0,
+        top: 20,
         bottom: 20,
       },
+      margin:{
+        left:20,
+        right:20,
+        bottom:20,
+        top:0
+      }
     },
     scales: {
       yAxes: [
         {
           type: 'logarithmic',
+
           ticks: {
             beginAtZero: true,
-            min: 1,
-            max: 2000,
-            precision: 0,
+            suggestedMin: 1,
+            maxTicksLimit : 9,
+            suggestedMax: 2000,
+            
+            
             callback: function (value, index, values) {
               return Number(value.toString());
             },
@@ -186,9 +195,10 @@ function GrowthTrendChart(props) {
           type: 'logarithmic',
           ticks: {
             beginAtZero: true,
-            min: 0,
-            max: 2000,
-            precision: 0,
+            suggestedMin: 0,
+            maxTicksLimit : 12,
+            suggestedMax: 2000,
+            minRotation:90,
             callback: function (value, index, values) {
               return Number(value.toString());
             },

--- a/src/components/deepdive.js
+++ b/src/components/deepdive.js
@@ -42,6 +42,8 @@ function DeepDive() {
     }
   };
 
+  //console.log(statesTimeSeries);
+
   return (
     <div className="cards-container">
       <Helmet>
@@ -53,7 +55,7 @@ function DeepDive() {
         <div className="card fadeInUp" style={{animationDelay: '0.7s'}}>
           <TotalConfirmedChart title="Total Cases" timeseries={timeseries} />
         </div>
-
+        <br/><br/>
         <div className="card fadeInUp" style={{animationDelay: '0.7s'}}>
           <DailyConfirmedChart title="Daily Cases" timeseries={timeseries} />
         </div>
@@ -74,7 +76,7 @@ function DeepDive() {
             data={statesTimeSeries}
           />
         </div>
-
+        <br/><br/><br/><br/>
         <div className="card fadeInUp" style={{animationDelay: '0.7s'}}>
           <GenderChart title="Patient Gender" data={rawData} />
         </div>


### PR DESCRIPTION
**…Deepdive Section**

**Description of PR****

The Labels of axes in States-Growth Trend Graph of Deepdive Section are overlapping in both Desktop and Mobile Mode View . So **I Changes its maxTicksLimit in ticks object under options constant and cubicInterPolarationmode to default and xAxis label rotation to 90deg.** And After that the problem of Overlapping is gone and viewed perfectly both in Desktop and Mobile Mode.

**Relevant Issues**  
 Overlap the titles of each graph in Mobile Mode

**Checklist**

- [ Yes] Compiles and passes lint tests
- [ Yes ] Properly formatted
- [ Yes] Tested on desktop
- [ Yes] Tested on phone

**Screenshots**

_Desktop Mode Modified View:_
![Screenshot (70)](https://user-images.githubusercontent.com/46219855/82209040-3ed45380-992a-11ea-9e28-a4034b129273.png)
_Mobile Mode Modified View:_
![Screenshot (71)](https://user-images.githubusercontent.com/46219855/82209129-61ff0300-992a-11ea-9383-1ae638a0e3a8.png)
_Proper Formatted Prove:_
![Screenshot (73)](https://user-images.githubusercontent.com/46219855/82209412-dcc81e00-992a-11ea-81fb-60f722384e21.png)


**Add relevant screenshots here**

![Screenshot (72)](https://user-images.githubusercontent.com/46219855/82209156-6deac500-992a-11ea-85eb-e1c47e067e27.png)

