### PR TITLE
Bug fix for issue #1924: Counter overlapping issue for smaller screens

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4917,6 +4917,18 @@ footer {
   }
 }
 
+@media (max-width: 480px) {
+  h1 {
+    font-size: 21px !important;
+  }
+}
+
+@media (max-width: 379px) {
+  h1 {
+    font-size: 18px !important;
+  }
+}
+
 // Dark Mode
 
 .dark-mode {


### PR DESCRIPTION
**Description of PR**

For smaller screen resolutions the counter values were overlapping producing a bad UX. This PR fixes that issue by reducing the font sizes of counters for smaller screen resolutions. There are 2 additional media queries present which reduces the font size in steps i.e. for width 480px and below the counter font size has been reduced from 24px to 21px and for width below 380px the font size has been reduced further to 18px. This fixes the counter overlapping issue. 
Future scope has also been considered such as when counter value changes to larger digits e.g. active cases reach a 6 digit count (currently active cases are in 5 digit count). There also this fix will work. All regression scenarios has been considered and tested to be working properly.

**Relevant Issues**  
Fixes #1924 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
Issue screenshot:
![image](https://user-images.githubusercontent.com/1254172/82323219-59273380-99f5-11ea-8621-1094283352fa.png)

After fix screenshot:
![image](https://user-images.githubusercontent.com/1254172/82323268-70662100-99f5-11ea-8226-b27f101d8463.png)

