### PR TITLE
Fix: issue of not closing expanded navbar on first time click of close btn in mobile device.

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -100,6 +100,7 @@ function Navbar({pages, darkMode}) {
 function Expand({expand, pages, setExpand, darkMode}) {
   const expandElement = useRef(null);
   const {t} = useTranslation();
+  const windowSize = useWindowSize();
 
   useEffectOnce(() => {
     anime({
@@ -115,7 +116,7 @@ function Expand({expand, pages, setExpand, darkMode}) {
       className="expand"
       ref={expandElement}
       onMouseLeave={() => {
-        setExpand(false);
+        if (windowSize.width > 768) setExpand(false);
       }}
     >
       {pages.map((page, i) => {

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -86,21 +86,15 @@ function Navbar({pages, darkMode}) {
       </div>
 
       {expand && (
-        <Expand
-          expand={expand}
-          pages={pages}
-          setExpand={setExpand}
-          darkMode={darkMode}
-        />
+        <Expand {...{expand, pages, setExpand, darkMode, windowSize}} />
       )}
     </animated.div>
   );
 }
 
-function Expand({expand, pages, setExpand, darkMode}) {
+function Expand({expand, pages, setExpand, darkMode, windowSize}) {
   const expandElement = useRef(null);
   const {t} = useTranslation();
-  const windowSize = useWindowSize();
 
   useEffectOnce(() => {
     anime({

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -116,7 +116,7 @@ function Expand({expand, pages, setExpand, darkMode}) {
       className="expand"
       ref={expandElement}
       onMouseLeave={() => {
-        if (windowSize.width > 768) setExpand(false);
+        if (windowSize.width > 769) setExpand(false);
       }}
     >
       {pages.map((page, i) => {


### PR DESCRIPTION
**Description of PR**
navbar is not getting closed on first time click of close btn after changing theme on mobile devices.
for more detail see issue.
**Relevant Issues**  
Fixes #1965

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![nav-fixed](https://user-images.githubusercontent.com/45959932/82689600-5f791200-9c78-11ea-9643-c5f61c267598.gif)
