### PR TITLE
Fix: Remove anchor in timeseries for mobile devices

### DIFF
--- a/src/components/timeseriesexplorer.js
+++ b/src/components/timeseriesexplorer.js
@@ -69,16 +69,18 @@ function TimeSeriesExplorer({
       ref={explorerElement}
     >
       <div className="timeseries-header">
-        <div
-          className={classnames('anchor', {
-            stickied: anchor === 'timeseries',
-          })}
-          onClick={() => {
-            setAnchor(anchor === 'timeseries' ? null : 'timeseries');
-          }}
-        >
-          <PinIcon />
-        </div>
+        {window.innerWidth > 769 && (
+          <div
+            className={classnames('anchor', {
+              stickied: anchor === 'timeseries',
+            })}
+            onClick={() => {
+              setAnchor(anchor === 'timeseries' ? null : 'timeseries');
+            }}
+          >
+            <PinIcon />
+          </div>
+        )}
 
         <h1>{t('Spread Trends')}</h1>
         <div className="tabs">


### PR DESCRIPTION
**Description of PR**
This PR fixes the issue caused by the anchor in mobile devices. It removes anchor for mobiles in timeseries.

**Relevant Issues**  
Fixes #2031 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone


