### PR TITLE
fix/#2036: Updated table styling to make it responsive for mobile devices

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4785,12 +4785,25 @@ footer {
   }
 
   table {
-    td {
-      max-width: 6.75rem;
+
+    overflow: hidden;
+
+    tr {
+
+      td {
+        font-size: 0.7rem;
+        max-width: 6.75rem;
+
+        .delta {
+          font-size: 9px !important;
+        }
+
+      }
     }
   }
 
   .cards-container {
+
     padding: .5rem;
 
     .cards {
@@ -5322,6 +5335,7 @@ footer {
     }
   }
 }
+
 
 // Animation Support
 


### PR DESCRIPTION
**Description of PR**
Stats Table was overflowing in the horizontal direction for small devices, resizing font sizes to make it responsive.

**Relevant Issues**  
Fixes #2036

**Checklist**

- [x] Compiles and passes lint tests
- [ ] Properly formatted
- [ ] Tested on desktop
- [ ] Tested on phone

**Screenshots**

<img width="1440" alt="Screenshot 2020-06-03 at 2 13 02 AM" src="https://user-images.githubusercontent.com/29687362/83569362-f9c33a80-a541-11ea-85c1-64d66b07141b.png">

