### PR TITLE
stop propagation for tooltips in table rows

### DIFF
--- a/src/components/row.js
+++ b/src/components/row.js
@@ -136,6 +136,7 @@ function PureDistrictRow({
                 wrap={true}
                 direction={'e'}
                 noDelay={true}
+                onClick={(e) => e.stopPropagation()}
               >
                 <Icon.Info />
               </Tooltip>
@@ -285,6 +286,7 @@ function Row({stateCode, data, regionHighlighted, setRegionHighlighted}) {
                   wrap={true}
                   direction={'e'}
                   noDelay={true}
+                  onClick={(e) => e.stopPropagation()}
                 >
                   <InfoIcon size={'small'} />
                 </Tooltip>


### PR DESCRIPTION
**Description of PR**
This PR fixes the issue that in mobile, tapping on tooltip icon in table rows also opens/closes the district sub-table.

**Relevant Issues**  
Fixes #2059

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
### before
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/11428805/83942699-b4d62700-a813-11ea-818a-704352e66dd8.gif)
### after
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/11428805/83942731-ecdd6a00-a813-11ea-879b-97aa0bbabb15.gif)
