### PR TITLE
Fix: yscale in daily section in timeseries when log mode is switched on 

### DIFF
--- a/src/components/timeseries.js
+++ b/src/components/timeseries.js
@@ -109,11 +109,12 @@ function TimeSeries({timeseries, dates, chartType, isUniform, isLog}) {
       .range([chartBottom, margin.top]);
 
     const generateYScale = (statistic) => {
-      if (isUniform && isLog && statistic !== 'tested') return yScaleUniformLog;
+      if (isUniform && chartType === 'total' && isLog && statistic !== 'tested')
+        return yScaleUniformLog;
 
       if (isUniform && statistic !== 'tested') return yScaleUniformLinear;
 
-      if (isLog)
+      if (chartType === 'total' && isLog)
         return d3
           .scaleLog()
           .clamp(true)


### PR DESCRIPTION
**Description of PR**
This PR fixes y-scale in daily section in timeseries when log mode is switched on

**Relevant Issues**  
Fixes #2064 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

### before
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/11428805/83943552-bce59500-a81a-11ea-8c9a-6318cf18cb73.gif)

### after
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/11428805/83943600-10f07980-a81b-11ea-82fb-ef902e33be54.gif)
