### PR TITLE
Fix: Prevent phone numbers from overflowing in search results

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1235,12 +1235,14 @@ h6 {
       .result-description {
         align-self: flex-start;
         font-size: 0.75rem;
+        margin-bottom: .5rem;
         margin-top: 1rem;
       }
 
       .result-contacts {
         display: flex;
         flex-direction: row;
+        flex-wrap: wrap;
         width: 100%;
       }
 
@@ -1254,7 +1256,7 @@ h6 {
         font-size: 0.75rem;
         height: 1rem;
         margin-right: .25rem;
-        margin-top: 0.5rem;
+        margin-top: 0.25rem;
         padding: 0.25rem;
         text-align: right;
 

--- a/src/components/knnresults.js
+++ b/src/components/knnresults.js
@@ -227,7 +227,7 @@ function KnnResults({userLocation, userState}) {
                 {result.properties.phone.split('\n').map((contact) => (
                   <div key={contact} className="result-contact">
                     <Phone />
-                    <a href={`tel:${contact}`}>{contact}</a>
+                    <a href={`tel:${contact}`}>{contact.replace(',', '')}</a>
                   </div>
                 ))}
               </div>
@@ -279,7 +279,7 @@ function KnnResults({userLocation, userState}) {
                 {result.properties.phone.split('\n').map((contact) => (
                   <div key={contact} className="result-contact">
                     <Phone />
-                    <a href={`tel:${contact}`}>{contact}</a>
+                    <a href={`tel:${contact}`}>{contact.replace(',', '')}</a>
                   </div>
                 ))}
               </div>

--- a/src/components/search.js
+++ b/src/components/search.js
@@ -329,7 +329,9 @@ function Search() {
                     {result.contact.split('\n').map((contact) => (
                       <div key={contact} className="result-contact">
                         <Icon.Phone />
-                        <a href={`tel:${contact}`}>{contact}</a>
+                        <a href={`tel:${contact}`}>
+                          {contact.replace(',', '')}
+                        </a>
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
**Description of PR**
This PR fixes the overflow issue of phone numbers in search results when there are more phone numbers. Also removed comma present in phone numbers.


**Relevant Issues**  
Fixes #2078 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
### before
![Screenshot (76)_LI](https://user-images.githubusercontent.com/11428805/83980344-90bd3780-a932-11ea-8009-a4e4a5e6d458.jpg)
### after
![Screenshot (76)](https://user-images.githubusercontent.com/11428805/83980353-9b77cc80-a932-11ea-80e2-871fc94fec6f.png)

