### PR TITLE
Fix: Map switcher position when language switcher is open

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -407,6 +407,7 @@ h6 {
   .state-left {
     margin-left: 2.5rem;
     margin-right: 2.5rem;
+    position: relative;
   }
 
   .state-right {
@@ -1526,7 +1527,7 @@ h6 {
   flex-direction: row;
   justify-content: space-between;
   position: absolute;
-  top: 12rem;
+  top: 7rem;
   width: 30rem;
 
   .highlight {

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -7,6 +7,7 @@ import StateDropdown from './statedropdown';
 import StateMeta from './statemeta';
 import TimeSeriesExplorer from './timeseriesexplorer';
 
+import {PRIMARY_STATISTICS} from '../constants';
 import {NUM_BARS_STATEPAGE, STATE_NAMES} from '../constants';
 import {
   fetcher,
@@ -155,50 +156,20 @@ function State(props) {
                 opacity: 0,
               }}
             ></div>
-            <div
-              className="clickable"
-              onClick={() => {
-                setMapStatistic('confirmed');
-                anime({
-                  targets: '.highlight',
-                  translateX: `${width * 0}px`,
-                  easing: 'spring(1, 80, 90, 10)',
-                });
-              }}
-            ></div>
-            <div
-              className="clickable"
-              onClick={() => {
-                setMapStatistic('active');
-                anime({
-                  targets: '.highlight',
-                  translateX: `${width * 0.25}px`,
-                  easing: 'spring(1, 80, 90, 10)',
-                });
-              }}
-            ></div>
-            <div
-              className="clickable"
-              onClick={() => {
-                setMapStatistic('recovered');
-                anime({
-                  targets: '.highlight',
-                  translateX: `${width * 0.5}px`,
-                  easing: 'spring(1, 80, 90, 10)',
-                });
-              }}
-            ></div>
-            <div
-              className="clickable"
-              onClick={() => {
-                setMapStatistic('deceased');
-                anime({
-                  targets: '.highlight',
-                  translateX: `${width * 0.75}px`,
-                  easing: 'spring(1, 80, 90, 10)',
-                });
-              }}
-            ></div>
+            {PRIMARY_STATISTICS.map((statistic, index) => (
+              <div
+                key={index}
+                className="clickable"
+                onClick={() => {
+                  setMapStatistic(statistic);
+                  anime({
+                    targets: '.highlight',
+                    translateX: `${width * index * 0.25}px`,
+                    easing: 'spring(1, 80, 90, 10)',
+                  });
+                }}
+              ></div>
+            ))}
           </div>
 
           <Level data={data[stateCode]} />


### PR DESCRIPTION
**Description of PR**
This PR positions the stats highlighted properly even when language switcher is open. Also shortened the code.

**Relevant Issues**  
Fixes #2089 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
### before
![Screenshot (77)_LI](https://user-images.githubusercontent.com/11428805/84062656-4c3aa600-a9dd-11ea-837f-72399b031c48.jpg)

### after
![Screenshot (78)](https://user-images.githubusercontent.com/11428805/84062671-50ff5a00-a9dd-11ea-9075-316b1c5898e9.png)


