### PR TITLE
[FIX] move window to top when toggling language

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -32,6 +32,7 @@ function Navbar({
       <div
         className="navbar-left"
         onClick={() => {
+          window.scrollTo({top: 0, behavior: 'smooth'});
           setShowLanguageSwitcher((prevState) => !prevState);
         }}
       >


### PR DESCRIPTION
Move window to top when toggling the language (clicking the language toggle button)

Step 1: Scroll to the bottom or in the mid.
Step 2: Now click the Language Toggle button. The screen will not move to top creating confusion for the user.

**Checklist**

- [X] Compiles and passes lint tests
- [X] Properly formatted
- [X] Tested on desktop
- [X] Tested on phone


