### PR TITLE
[FIX] fixes #2032: Search box not working after visiting the demographics page

### DIFF
--- a/src/components/demographics.js
+++ b/src/components/demographics.js
@@ -256,11 +256,11 @@ function Demographics(props) {
               maxDate={subDays(new Date(), 1)}
               format="dd/MM/y"
               calendarIcon={<Icon.Calendar />}
-              inputProps={
-                (onkeydown = (e) => {
-                  e.preventDefault();
-                })
-              }
+              // inputProps={
+              //   (onkeydown = (e) => {
+              //     e.preventDefault();
+              //   })
+              // }
               clearIcon={<Icon.XCircle />}
               onChange={(date) => {
                 setFilterDate(date);


### PR DESCRIPTION
**Description of PR**

This PR will fix the issue #2032 however when date picker is opened in demographics, the arrow keys will scroll the body of the page instead of changing the selection in the date picker.

**Relevant Issues**  
Fixes #2032 

**Checklist**

- [X] Compiles and passes lint tests
- [X] Properly formatted
- [X] Tested on desktop
- [X] Tested on phone

**Screenshots**
(Typing in search bar at home after visiting the demographics page)

Before:(nothing is getting typed)
![image](https://user-images.githubusercontent.com/51584570/84484140-f7867c00-acb7-11ea-8a5e-b06d6a43f6a1.png)

After:(search bar typing is working properly)
![image](https://user-images.githubusercontent.com/51584570/84484027-cd34be80-acb7-11ea-8406-27d69c42731a.png)

