### PR TITLE
Fix: clickaway event on whole state dropdown

### DIFF
--- a/src/components/statedropdown.js
+++ b/src/components/statedropdown.js
@@ -12,9 +12,13 @@ const StateDropdown = ({stateCode}) => {
   const history = useHistory();
   const {t} = useTranslation();
 
-  useClickAway(dropdownRef, () => {
-    setShowDropdown(false);
-  });
+  useClickAway(
+    dropdownRef,
+    () => {
+      setShowDropdown(false);
+    },
+    ['click']
+  );
 
   const transitions = useTransition(showDropdown, null, {
     from: {
@@ -40,12 +44,13 @@ const StateDropdown = ({stateCode}) => {
   });
 
   return (
-    <div className="StateDropdown" ref={dropdownRef}>
+    <div className="StateDropdown">
       <h1
         className="state-name"
         onClick={() => {
           setShowDropdown((prevData) => !prevData);
         }}
+        ref={dropdownRef}
       >
         {t(STATE_NAMES[stateCode])}
       </h1>

--- a/src/components/statedropdown.js
+++ b/src/components/statedropdown.js
@@ -40,13 +40,12 @@ const StateDropdown = ({stateCode}) => {
   });
 
   return (
-    <div className="StateDropdown">
+    <div className="StateDropdown" ref={dropdownRef}>
       <h1
         className="state-name"
         onClick={() => {
           setShowDropdown((prevData) => !prevData);
         }}
-        ref={dropdownRef}
       >
         {t(STATE_NAMES[stateCode])}
       </h1>

--- a/src/components/statedropdown.js
+++ b/src/components/statedropdown.js
@@ -12,13 +12,9 @@ const StateDropdown = ({stateCode}) => {
   const history = useHistory();
   const {t} = useTranslation();
 
-  useClickAway(
-    dropdownRef,
-    () => {
-      setShowDropdown(false);
-    },
-    ['click']
-  );
+  useClickAway(dropdownRef, () => {
+    setShowDropdown(false);
+  });
 
   const transitions = useTransition(showDropdown, null, {
     from: {
@@ -44,13 +40,12 @@ const StateDropdown = ({stateCode}) => {
   });
 
   return (
-    <div className="StateDropdown">
+    <div className="StateDropdown" ref={dropdownRef}>
       <h1
         className="state-name"
         onClick={() => {
           setShowDropdown((prevData) => !prevData);
         }}
-        ref={dropdownRef}
       >
         {t(STATE_NAMES[stateCode])}
       </h1>


### PR DESCRIPTION
**Description of PR**
This PR fixes the issue that dropdown closes on scrolling it in mobile in state page.

**Relevant Issues**  
Fixes #2141 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
### before
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/11428805/84568322-3b52b180-ad9c-11ea-9ebb-4152a25845ee.gif)
### after
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/11428805/84568368-a0a6a280-ad9c-11ea-81e3-ce6a344449af.gif)
