### PR TITLE
Slightly faster pageloads

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+build/**
+node_modules/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8152,11 +8152,6 @@
         "side-channel": "^1.0.2"
       }
     },
-    "intersection-observer": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.10.0.tgz",
-      "integrity": "sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ=="
-    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2804,14 +2804,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
-    "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "requires": {
-        "follow-redirects": "1.5.10"
-      }
-    },
     "axobject-query": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "i18next-browser-languagedetector": "^4.2.0",
     "i18next-http-backend": "^1.0.15",
     "immer": "^6.0.9",
-    "intersection-observer": "^0.10.0",
     "leaflet": "^1.6.0",
     "leaflet-knn": "^0.1.0",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@primer/octicons-v2-react": "0.0.0-53e900d",
     "@testing-library/jest-dom": "^5.9.0",
     "@testing-library/react": "^10.0.6",
-    "axios": "^0.19.2",
     "classnames": "^2.2.6",
     "corejs-typeahead": "^1.3.1",
     "d3-array": "^2.4.0",

--- a/public/index.html
+++ b/public/index.html
@@ -194,24 +194,27 @@
 
   <!-- Google Analytics -->
   <script>
-    (function(i,s,o,g,r,a,m){
-      i['GoogleAnalyticsObject']=r;
-      i[r]=i[r] || function(){
-        (i[r].q=i[r].q||[]).push(arguments)
-      },
-      i[r].l=1*new Date();
+    (function (i, s, o, g, r, a, m) {
+      i['GoogleAnalyticsObject'] = r;
+      (i[r] =
+        i[r] ||
+        function () {
+          (i[r].q = i[r].q || []).push(arguments);
+        }),
+        (i[r].l = 1 * new Date());
 
       setTimeout(() => {
-        a=s.createElement(o), m=s.getElementsByTagName(o)[0];
-        a.async=1;
-        a.src=g;
-        m.parentNode.insertBefore(a,m);
+        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
       }, 3000); // Wait 3 seconds
-
-    })(window,document,
-       'script',
-       'https://www.google-analytics.com/analytics.js',
-       'ga'
+    })(
+      window,
+      document,
+      'script',
+      'https://www.google-analytics.com/analytics.js',
+      'ga'
     );
 
     ga('create', 'UA-160698988-1', {

--- a/public/index.html
+++ b/public/index.html
@@ -192,20 +192,33 @@
     })();
   </script>
 
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script
-    async
-    src="https://www.googletagmanager.com/gtag/js?id=UA-160698988-1"
-  ></script>
+  <!-- Google Analytics -->
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
-    }
-    gtag('js', new Date());
-    gtag('config', 'UA-160698988-1', {
+    (function(i,s,o,g,r,a,m){
+      i['GoogleAnalyticsObject']=r;
+      i[r]=i[r] || function(){
+        (i[r].q=i[r].q||[]).push(arguments)
+      },
+      i[r].l=1*new Date();
+
+      setTimeout(() => {
+        a=s.createElement(o), m=s.getElementsByTagName(o)[0];
+        a.async=1;
+        a.src=g;
+        m.parentNode.insertBefore(a,m);
+      }, 3000); // Wait 3 seconds
+
+    })(window,document,
+       'script',
+       'https://www.google-analytics.com/analytics.js',
+       'ga'
+    );
+
+    ga('create', 'UA-160698988-1', {
       site_speed_sample_rate: 1,
       sample_rate: 1,
     });
+    ga('send', 'pageview');
   </script>
+  <!-- End Google Analytics -->
 </html>

--- a/src/components/banner.js
+++ b/src/components/banner.js
@@ -1,6 +1,7 @@
-import axios from 'axios';
 import React, {useState, useEffect, useCallback} from 'react';
 // import {useTranslation} from 'react-i18next';
+
+const DATA_URL = 'https://api.covid19india.org/website_data.json';
 
 function Banner(props) {
   // const {t} = useTranslation();
@@ -8,14 +9,14 @@ function Banner(props) {
   const [snippet, setSnippet] = useState();
 
   useEffect(() => {
-    axios
-      .get('https://api.covid19india.org/website_data.json')
-      .then((response) => {
-        setSnippets(response.data.factoids || []);
+    fetch(DATA_URL)
+      .then((response) => { return response.json(); })
+      .then((data) => {
+        setSnippets(data.factoids || []);
         setSnippet(
-          response.data.factoids[
+          data.factoids[
             Math.floor(
-              Math.random() * (response.data.factoids.length - 1 - 0) + 0
+              Math.random() * (data.factoids.length - 1 - 0) + 0
             )
           ] || ''
         );

--- a/src/components/banner.js
+++ b/src/components/banner.js
@@ -10,14 +10,14 @@ function Banner(props) {
 
   useEffect(() => {
     fetch(DATA_URL)
-      .then((response) => { return response.json(); })
+      .then((response) => {
+        return response.json();
+      })
       .then((data) => {
         setSnippets(data.factoids || []);
         setSnippet(
           data.factoids[
-            Math.floor(
-              Math.random() * (data.factoids.length - 1 - 0) + 0
-            )
+            Math.floor(Math.random() * (data.factoids.length - 1 - 0) + 0)
           ] || ''
         );
       })

--- a/src/components/demographics.js
+++ b/src/components/demographics.js
@@ -62,10 +62,12 @@ function Demographics(props) {
   }, [filters.dateannounced]);
 
   useEffect(() => {
-    let url = `https://api.covid19india.org/raw_data${getPartition()}.json`;
+    const url = `https://api.covid19india.org/raw_data${getPartition()}.json`;
     try {
       fetch(url)
-        .then((response) => { return response.json(); })
+        .then((response) => {
+          return response.json();
+        })
         .then((data) => {
           setPatients(data.raw_data.reverse());
           setFetched(true);

--- a/src/components/demographics.js
+++ b/src/components/demographics.js
@@ -4,7 +4,6 @@ import Patients from './patients';
 
 import {RAW_DATA_PARTITIONS} from '../constants';
 
-import axios from 'axios';
 import {format, subDays, isWithinInterval, parse} from 'date-fns';
 import React, {useState, useEffect, useCallback} from 'react';
 import DatePicker from 'react-date-picker';
@@ -63,11 +62,12 @@ function Demographics(props) {
   }, [filters.dateannounced]);
 
   useEffect(() => {
+    let url = `https://api.covid19india.org/raw_data${getPartition()}.json`;
     try {
-      axios
-        .get(`https://api.covid19india.org/raw_data${getPartition()}.json`)
-        .then((response) => {
-          setPatients(response.data.raw_data.reverse());
+      fetch(url)
+        .then((response) => { return response.json(); })
+        .then((data) => {
+          setPatients(data.raw_data.reverse());
           setFetched(true);
         });
     } catch (err) {

--- a/src/components/essentials.js
+++ b/src/components/essentials.js
@@ -61,10 +61,12 @@ const Essentials = (props) => {
 
   const getCurrentAddress = (lat, lng) => {
     try {
-      let base = 'https://api.bigdatacloud.net/data/reverse-geocode-client';
-      let url = `${base}?latitude=${lat}&longitude=${lng}&localityLanguage=en`;
+      const base = 'https://api.bigdatacloud.net/data/reverse-geocode-client';
+      const url = `${base}?latitude=${lat}&longitude=${lng}&localityLanguage=en`;
       fetch(url)
-        .then((response) => { return response.json(); })
+        .then((response) => {
+          return response.json();
+        })
         .then((data) => {
           setCurrentAddress(data.locality);
           setCurrentState(data.principalSubdivision);

--- a/src/components/essentials.js
+++ b/src/components/essentials.js
@@ -1,6 +1,5 @@
 import KnnResults from './knnresults';
 
-import axios from 'axios';
 import React, {useState, useEffect} from 'react';
 import ContentLoader from 'react-content-loader';
 import * as Icon from 'react-feather';
@@ -62,17 +61,13 @@ const Essentials = (props) => {
 
   const getCurrentAddress = (lat, lng) => {
     try {
-      axios
-        .get(
-          'https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=' +
-            lat +
-            '&longitude=' +
-            lng +
-            '&localityLanguage=en'
-        )
-        .then((response) => {
-          setCurrentAddress(response.data.locality);
-          setCurrentState(response.data.principalSubdivision);
+      let base = 'https://api.bigdatacloud.net/data/reverse-geocode-client';
+      let url = `${base}?latitude=${lat}&longitude=${lng}&localityLanguage=en`;
+      fetch(url)
+        .then((response) => { return response.json(); })
+        .then((data) => {
+          setCurrentAddress(data.locality);
+          setCurrentState(data.principalSubdivision);
         });
     } catch (err) {
       console.log(err);

--- a/src/components/faq.js
+++ b/src/components/faq.js
@@ -17,7 +17,9 @@ function FAQ(props) {
 
   const getFAQs = () => {
     fetch(DATA_URL)
-      .then((response) => { return response.json(); })
+      .then((response) => {
+        return response.json();
+      })
       .then((data) => {
         setFaq(data.faq);
       })

--- a/src/components/faq.js
+++ b/src/components/faq.js
@@ -1,6 +1,8 @@
-import axios from 'axios';
 import React, {useState, useEffect} from 'react';
 import {Helmet} from 'react-helmet';
+
+// TODO(slightlyoff): factor out common JSON parsing & caching of this file
+const DATA_URL = 'https://api.covid19india.org/website_data.json';
 
 function FAQ(props) {
   const [faq, setFaq] = useState([]);
@@ -14,10 +16,10 @@ function FAQ(props) {
   }, []);
 
   const getFAQs = () => {
-    axios
-      .get('https://api.covid19india.org/website_data.json')
-      .then((response) => {
-        setFaq(response.data['faq']);
+    fetch(DATA_URL)
+      .then((response) => { return response.json(); })
+      .then((data) => {
+        setFaq(data.faq);
       })
       .catch((error) => {
         console.log(error);

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -2,8 +2,6 @@ import {MAP_META} from '../constants';
 import useStickySWR from '../hooks/usestickyswr';
 import {fetcher} from '../utils/commonfunctions';
 
-import 'intersection-observer';
-
 import React, {useState, useRef, lazy, Suspense} from 'react';
 import {Helmet} from 'react-helmet';
 import {useIsVisible} from 'react-is-visible';

--- a/src/components/knnresults.js
+++ b/src/components/knnresults.js
@@ -1,4 +1,3 @@
-import axios from 'axios';
 import classnames from 'classnames';
 import produce from 'immer';
 import {layer} from 'leaflet';
@@ -39,11 +38,10 @@ function KnnResults({userLocation, userState}) {
   }, []);
 
   const getJSON = useCallback(() => {
-    axios
-      .get('https://api.covid19india.org/resources/geoResources.json')
-      .then((response) => {
-        setGeoData(response.data);
-      })
+    let url = 'https://api.covid19india.org/resources/geoResources.json';
+    fetch(url)
+      .then((response) => { return response.json(); })
+      .then(setGeoData)
       .catch((error) => {
         console.log(error);
       });

--- a/src/components/knnresults.js
+++ b/src/components/knnresults.js
@@ -38,9 +38,11 @@ function KnnResults({userLocation, userState}) {
   }, []);
 
   const getJSON = useCallback(() => {
-    let url = 'https://api.covid19india.org/resources/geoResources.json';
+    const url = 'https://api.covid19india.org/resources/geoResources.json';
     fetch(url)
-      .then((response) => { return response.json(); })
+      .then((response) => {
+        return response.json();
+      })
       .then(setGeoData)
       .catch((error) => {
         console.log(error);

--- a/src/components/timeseriesexplorer.js
+++ b/src/components/timeseriesexplorer.js
@@ -7,8 +7,6 @@ import {
 } from '../constants';
 import {getIndiaYesterdayISO, parseIndiaDate} from '../utils/commonfunctions';
 
-import 'intersection-observer';
-
 import {PinIcon, IssueOpenedIcon} from '@primer/octicons-v2-react';
 import classnames from 'classnames';
 import {formatISO, sub} from 'date-fns';

--- a/src/testUtils/index.js
+++ b/src/testUtils/index.js
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 import {promises as fs} from 'fs';
 
 export function removeFileExtension(fileName) {
@@ -11,9 +9,8 @@ function removeUnknown(e) {
 }
 
 export async function getStatesAndDistrictsFromAPI() {
-  const stateDistrictWiseResponse = (
-    await axios.get('https://api.covid19india.org/state_district_wise.json')
-  ).data;
+  let url = 'https://api.covid19india.org/state_district_wise.json';
+  const stateDistrictWiseResponse = await (await fetch(url)).json();
   const states = Object.keys(stateDistrictWiseResponse).filter(removeUnknown);
   const result = {};
   states.map((stateName) => {

--- a/src/utils/commonfunctions.js
+++ b/src/utils/commonfunctions.js
@@ -1,6 +1,5 @@
 import {INDIA_ISO_SUFFIX, LOCALE_SHORTHANDS} from '../constants';
 
-import axios from 'axios';
 import {format, formatDistance, formatISO, subDays} from 'date-fns';
 import {utcToZonedTime} from 'date-fns-tz';
 import i18n from 'i18next';
@@ -106,4 +105,6 @@ export const getStatistic = (data, type, statistic, normalizer = 1) => {
   return count / normalizer;
 };
 
-export const fetcher = (url) => axios(url).then((response) => response.data);
+export const fetcher = (url) => {
+  return fetch(url).then((response) => { return response.json() }); 
+}

--- a/src/utils/commonfunctions.js
+++ b/src/utils/commonfunctions.js
@@ -106,5 +106,7 @@ export const getStatistic = (data, type, statistic, normalizer = 1) => {
 };
 
 export const fetcher = (url) => {
-  return fetch(url).then((response) => { return response.json() }); 
-}
+  return fetch(url).then((response) => {
+    return response.json();
+  });
+};


### PR DESCRIPTION
**Description of PR**

Removes polyfills for `fetch()` (axios) and `IntersectionObserver` and delays loading of Google Analytics. In discussion with Jeremy it seems that losing compatibility with IE11 isn't a major issue.

The gains from delaying fetching of the GA scripts, and avoiding the gtm indirection, will be minimal for users on fast networks but should help those on slower links.

There's a lot of work remaining here to understand what the heck WebPack is doing for the default route and ensuring that we can preload the script that it's currently pulling in over a pretty janky stair-step, which you can see here at line 8:

https://www.webpagetest.org/result/200613_9S_fcc0999074dbca2982bc4e49dca95d21/1/details/#waterfall_view_step1