### PR TITLE
[Fixed] highlighting of two nav-icon on click of about icon

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -123,7 +123,7 @@ function Navbar({
             </span>
             <span>
               <Link to="/blog">
-                <Icon.Book {...activeNavIcon('/about')} />
+                <Icon.Book {...activeNavIcon('/blog')} />
               </Link>
             </span>
             <span>{windowSize.width > 768 && <SunMoon {...{darkMode}} />}</span>


### PR DESCRIPTION
**Description of PR**
two nav icons are highlighted i.e. about and blog icon.

**Relevant Issues**  
Fixes #2156

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Screenshot from 2020-06-16 22-10-44](https://user-images.githubusercontent.com/45959932/84802474-46b50f80-b01e-11ea-9494-f4de2953e36a.png)

