### PR TITLE
Add percentage next to the active, recovered and deceased titles

### DIFF
--- a/src/__tests__/components/Level.test.js
+++ b/src/__tests__/components/Level.test.js
@@ -29,6 +29,6 @@ test('Level renders total state data', () => {
   const {container} = render(<Level {...{data}} />);
 
   expect(container).toHaveTextContent(
-    'Confirmed+153883Active 872Recovered+25Deceased+13'
+    'Confirmed +153883Active (98.75%) 872Recovered (0.57%)+25Deceased (0.34%)+13'
   );
 });

--- a/src/components/level.js
+++ b/src/components/level.js
@@ -1,15 +1,18 @@
 import {PRIMARY_STATISTICS} from '../constants';
-import {capitalize, formatNumber, getStatistic} from '../utils/commonfunctions';
+import {
+  capitalize,
+  formatNumber,
+  getPercentageText,
+  getStatistic,
+} from '../utils/commonfunctions';
 
 import {HeartFillIcon} from '@primer/octicons-v2-react';
 import classnames from 'classnames';
 import equal from 'fast-deep-equal';
 import React from 'react';
-import {useTranslation} from 'react-i18next';
 import {animated, useSpring, config, useTrail} from 'react-spring';
 
-function PureLevelItem({statistic, total, delta}) {
-  const {t} = useTranslation();
+function PureLevelItem({statistic, total, delta, confirmed}) {
   const spring = useSpring(
     {
       total: total,
@@ -21,7 +24,13 @@ function PureLevelItem({statistic, total, delta}) {
 
   return (
     <React.Fragment>
-      <h5>{t(capitalize(statistic))}</h5>
+      <h5>
+        {capitalize(statistic) +
+          ' ' +
+          (statistic !== 'confirmed'
+            ? getPercentageText(confirmed, total)
+            : '')}
+      </h5>
       <animated.h4>
         {statistic !== 'active' ? (
           delta > 0 ? (
@@ -65,6 +74,7 @@ function Level({data}) {
             {...{statistic}}
             total={getStatistic(data, 'total', statistic)}
             delta={getStatistic(data, 'delta', statistic)}
+            confirmed={getStatistic(data, 'total', 'confirmed')}
           />
         </animated.div>
       ))}

--- a/src/components/level.js
+++ b/src/components/level.js
@@ -10,9 +10,11 @@ import {HeartFillIcon} from '@primer/octicons-v2-react';
 import classnames from 'classnames';
 import equal from 'fast-deep-equal';
 import React from 'react';
+import {useTranslation} from 'react-i18next';
 import {animated, useSpring, config, useTrail} from 'react-spring';
 
 function PureLevelItem({statistic, total, delta, confirmed}) {
+  const {t} = useTranslation();
   const spring = useSpring(
     {
       total: total,
@@ -25,7 +27,7 @@ function PureLevelItem({statistic, total, delta, confirmed}) {
   return (
     <React.Fragment>
       <h5>
-        {capitalize(statistic) +
+        {t(capitalize(statistic)) +
           ' ' +
           (statistic !== 'confirmed'
             ? getPercentageText(confirmed, total)

--- a/src/utils/commonfunctions.js
+++ b/src/utils/commonfunctions.js
@@ -72,6 +72,11 @@ export const capitalize = (s) => {
   return s.charAt(0).toUpperCase() + s.slice(1);
 };
 
+export const getPercentageText = (confirmed, total) => {
+  const percentage = (total * 100) / confirmed;
+  return '(' + Math.round(percentage * 100) / 100 + '%' + ')';
+};
+
 export const capitalizeAll = (s) => {
   if (typeof s !== 'string') return '';
   const str = s.toLowerCase().split(' ');


### PR DESCRIPTION
**Description of PR**

Added percentage to title tags (Active, Recovered, Deceased)

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

<img width="609" alt="Screen Shot 2020-06-17 at 6 54 54 PM" src="https://user-images.githubusercontent.com/6314101/84903737-175cdc00-b0cc-11ea-8cad-b82c9853ca9c.png">

