### PR TITLE
Fix : Selecting "Lakshadweep" shows graphs with no data

### DIFF
--- a/locales/all_locales.json
+++ b/locales/all_locales.json
@@ -813,5 +813,6 @@
   "View updates on Twitter": "View updates on Twitter",
   "Join Telegram to Collaborate!": "Join Telegram to Collaborate!",
   "Back": "Back",
-  "District-wise {{mapOption}} numbers are under reconciliation": "District-wise {{mapOption}} numbers are under reconciliation"
+  "District-wise {{mapOption}} numbers are under reconciliation": "District-wise {{mapOption}} numbers are under reconciliation",
+  "There are no COVID-19 reports or data available at this point of time": "There are no COVID-19 reports or data available at this point of time"
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -2465,6 +2465,15 @@ abbr {
     margin: 0;
     margin-top: 1rem;
   }
+
+  .info {
+    margin: 1rem 0 0;
+    align-self: flex-start;
+    .text {
+      margin-top: .15rem;
+      margin-left: .25rem;
+    }
+  }
 }
 
 .TimeSeries {

--- a/src/components/timeseriesexplorer.js
+++ b/src/components/timeseriesexplorer.js
@@ -77,7 +77,7 @@ function Info() {
       <IssueOpenedIcon size={24} />
       <div className="text">
         {t(
-          'There is no COVID-19 reports or data available at this point of time'
+          'There are no COVID-19 reports or data available at this point of time'
         )}
       </div>
     </div>

--- a/src/components/timeseriesexplorer.js
+++ b/src/components/timeseriesexplorer.js
@@ -20,6 +20,70 @@ const TimeSeries = lazy(() =>
   import('./timeseries' /* webpackChunkName: "TimeSeries" */)
 );
 
+function Chart({
+  isVisible,
+  stateCode,
+  timeseries,
+  dates,
+  chartType,
+  isUniform,
+  isLog,
+}) {
+  return (
+    isVisible && (
+      <Suspense fallback={<TimeseriesLoader />}>
+        <TimeSeries
+          {...{timeseries, dates, chartType, isUniform, isLog, stateCode}}
+        />
+      </Suspense>
+    )
+  );
+}
+
+function Pills(props) {
+  const {t} = useTranslation();
+  return (
+    <div className="pills">
+      {Object.values(TIMESERIES_OPTIONS).map((option) => (
+        <button
+          key={option}
+          type="button"
+          className={classnames({selected: props.timeseriesOption === option})}
+          onClick={() => props.setTimeseriesOption(option)}
+        >
+          {t(option)}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Alert() {
+  const {t} = useTranslation();
+  return (
+    <div className="alert">
+      <IssueOpenedIcon size={24} />
+      <div className="alert-right">
+        {t('Tested chart is independent of uniform scaling')}
+      </div>
+    </div>
+  );
+}
+
+function Info() {
+  const {t} = useTranslation();
+  return (
+    <div className="alert info">
+      <IssueOpenedIcon size={24} />
+      <div className="text">
+        {t(
+          'There is no COVID-19 reports or data available at this point of time'
+        )}
+      </div>
+    </div>
+  );
+}
+
 function TimeSeriesExplorer({
   timeseries,
   date: timelineDate,
@@ -152,34 +216,28 @@ function TimeSeriesExplorer({
         )}
       </div>
 
-      {isVisible && (
-        <Suspense fallback={<TimeseriesLoader />}>
-          <TimeSeries
-            stateCode={regionHighlighted.stateCode}
-            {...{timeseries, dates, chartType, isUniform, isLog}}
+      {timeseries ? (
+        <>
+          <Chart
+            {...{
+              timeseries,
+              dates,
+              chartType,
+              isUniform,
+              isLog,
+              isVisible,
+              stateCode: regionHighlighted.stateCode,
+            }}
           />
-        </Suspense>
+          <Pills
+            timeseriesOption={timeseriesOption}
+            setTimeseriesOption={setTimeseriesOption}
+          />
+          <Alert />
+        </>
+      ) : (
+        <Info />
       )}
-
-      <div className="pills">
-        {Object.values(TIMESERIES_OPTIONS).map((option) => (
-          <button
-            key={option}
-            type="button"
-            className={classnames({selected: timeseriesOption === option})}
-            onClick={() => setTimeseriesOption(option)}
-          >
-            {t(option)}
-          </button>
-        ))}
-      </div>
-
-      <div className="alert">
-        <IssueOpenedIcon size={24} />
-        <div className="alert-right">
-          {t('Tested chart is independent of uniform scaling')}
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/components/timeseriesexplorer.js
+++ b/src/components/timeseriesexplorer.js
@@ -40,7 +40,7 @@ function Chart({
   );
 }
 
-function Pills(props) {
+function Pills({timeseriesOption, setTimeseriesOption}) {
   const {t} = useTranslation();
   return (
     <div className="pills">
@@ -48,8 +48,8 @@ function Pills(props) {
         <button
           key={option}
           type="button"
-          className={classnames({selected: props.timeseriesOption === option})}
-          onClick={() => props.setTimeseriesOption(option)}
+          className={classnames({selected: timeseriesOption === option})}
+          onClick={() => setTimeseriesOption(option)}
         >
           {t(option)}
         </button>


### PR DESCRIPTION
**Description of PR**

When no data or report is available for a selected state in the Spread Trends section, a small alert box with a description will be shown!

**Relevant Issues**  
Fixes #2154 


**Screenshots**  

![image](https://user-images.githubusercontent.com/7911543/85135144-42296a80-b25b-11ea-9082-9e026508eea2.png)

