### PR TITLE
fixed search issue due to e.preventdefault

### DIFF
--- a/src/components/demographics.js
+++ b/src/components/demographics.js
@@ -260,7 +260,9 @@ function Demographics(props) {
               calendarIcon={<Icon.Calendar />}
               inputProps={
                 (onkeydown = (e) => {
-                  e.preventDefault();
+                  if (e.keyCode === 38 || e.keyCode === 40) {
+                    return false;
+                  }
                 })
               }
               clearIcon={<Icon.XCircle />}


### PR DESCRIPTION
**Description of PR**
Search box not working after visiting demographics page.

Fixed by adding specific key code for event.preventDefault. Behaves as expected in other cases.

**Relevant Issues**  
Fixes #2200 #2032 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [ ] Tested on phone
