### PR TITLE
Fix: Wrap text in side-bar logo consistently

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -170,6 +170,10 @@ h6 {
     font-weight: 900;
     text-transform: uppercase;
 
+    br {
+      display: none;
+    }
+
     span {
       color: $pblue;
     }
@@ -3691,8 +3695,10 @@ footer {
       padding-bottom: 2rem;
       padding-top: 2rem;
       text-align: center;
-      width: 46px;
-      word-wrap: break-word;
+
+      br {
+        display: block;
+      }
     }
 
     .navbar-right {

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -57,7 +57,9 @@ function Navbar({
 
       <div className="navbar-middle">
         <Link to="/" onClick={setExpand.bind(this, false)}>
-          Covid19<span>India</span>
+          Covid19
+          <br />
+          <span>India</span>
         </Link>
       </div>
 


### PR DESCRIPTION
**Description of PR**
The text in side-bar logo wraps inconsistently on different desktop / tablet devices. This PR fixes this issue by adding a `<br/>` tag in-between the words and setting the `display` property on the `<br/>` tag accordingly.

**Relevant Issues**  
Fixes #1707 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Add relevant screenshots here
