### PR TITLE
Set header color for iOS PWA

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,9 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />


### PR DESCRIPTION
**Description of PR**

This PR explicitly adds support for PWA on Apple devices and sets the header color to white (from black) to match the rest of the website

**Relevant Issues**  
Fixes #...

**Checklist**

- [ ] Compiles and passes lint tests
- [ ] Properly formatted
- [ ] Tested on desktop
- [x] Tested on phone

**Screenshots**

Add relevant screenshots here
