### PR TITLE
Update App.scss

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1311,7 +1311,7 @@ h6 {
       flex-direction: column;
       justify-content: space-around;
       padding: 1rem;
-      position: absolute;
+      position: static;
       top: 13.25rem;
 
       .highlight {


### PR DESCRIPTION
The position of the 'actions timeline' remains as it is even when you click on (or not, looking as if it is permanently set there '') ) language selection button. That portion of dates-timeline remains in its place whatsoever.
I first thought it is flex-box issue and was somewhat right. The thing is that is, it is a simple layout error due to wrong value assigned to position in 'header timeline'. The assigned value is set as 'absolute' but it is rather 'static'.
Assigning the value of position in header timeline as 'static' solves this issue.

Description of PR

This layout issue is easily solved by assigning position value as 'static' in timeline of header scss code of App. 

Relevant Issues  
Fixes #2227 

Checklist

+ [x] Compiles and passes lint tests
+ [x] Properly formatted
+ [x] Tested on desktop
+ [x] Tested on phone
