### PR TITLE
Feat: Add swipe support on Map Explorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15079,6 +15079,14 @@
         "prop-types": "^15.5.8"
       }
     },
+    "react-swipeable": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-5.5.1.tgz",
+      "integrity": "sha512-EQObuU3Qg3JdX3WxOn5reZvOSCpU4fwpUAs+NlXSN3y+qtsO2r8VGkVnOQzmByt3BSYj9EWYdUOUfi7vaMdZZw==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      }
+    },
     "react-test-renderer": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",
     "react-spring": "^8.0.27",
+    "react-swipeable": "^5.5.1",
     "react-use": "^15.3.0",
     "react-use-gesture": "^7.0.15",
     "requestidlecallback": "^0.3.0",

--- a/src/components/MapExplorer.js
+++ b/src/components/MapExplorer.js
@@ -172,13 +172,13 @@ function MapExplorer({
   });
 
   const swipeHandlers = useSwipeable({
-    onSwipedLeft: () => {
+    onSwipedRight: () => {
       const currentIndex = PRIMARY_STATISTICS.indexOf(mapStatistic);
       const toIndex =
         currentIndex > 0 ? currentIndex - 1 : PRIMARY_STATISTICS.length - 1;
       setMapStatistic(PRIMARY_STATISTICS[toIndex]);
     },
-    onSwipedRight: () => {
+    onSwipedLeft: () => {
       const currentIndex = PRIMARY_STATISTICS.indexOf(mapStatistic);
       const toIndex =
         currentIndex < PRIMARY_STATISTICS.length - 1 ? currentIndex + 1 : 0;
@@ -281,7 +281,12 @@ function MapExplorer({
         </div>
       </div>
 
-      <div ref={mapExplorerRef} className="fadeInUp" style={trail[3]}>
+      <div
+        ref={mapExplorerRef}
+        className="fadeInUp"
+        style={trail[3]}
+        {...swipeHandlers}
+      >
         {mapStatistic && (
           <Suspense
             fallback={
@@ -294,14 +299,12 @@ function MapExplorer({
               />
             }
           >
-            <div {...swipeHandlers}>
-              <MapVisualizer
-                {...{mapCode, mapView, mapViz}}
-                data={mapData}
-                {...{regionHighlighted, setRegionHighlighted}}
-                statistic={mapStatistic}
-              ></MapVisualizer>
-            </div>
+            <MapVisualizer
+              {...{mapCode, mapView, mapViz}}
+              data={mapData}
+              {...{regionHighlighted, setRegionHighlighted}}
+              statistic={mapStatistic}
+            ></MapVisualizer>
           </Suspense>
         )}
       </div>

--- a/src/components/MapExplorer.js
+++ b/src/components/MapExplorer.js
@@ -32,6 +32,7 @@ import React, {
 import {useTranslation} from 'react-i18next';
 import {useHistory} from 'react-router-dom';
 import {animated, useSpring} from 'react-spring';
+import {useSwipeable} from 'react-swipeable';
 import {useWindowSize} from 'react-use';
 
 const MapVisualizer = lazy(() => import('./MapVisualizer'));
@@ -170,6 +171,21 @@ function MapExplorer({
     config: {tension: 250, ...SPRING_CONFIG_NUMBERS},
   });
 
+  const swipeHandlers = useSwipeable({
+    onSwipedLeft: () => {
+      const currentIndex = PRIMARY_STATISTICS.indexOf(mapStatistic);
+      const toIndex =
+        currentIndex > 0 ? currentIndex - 1 : PRIMARY_STATISTICS.length - 1;
+      setMapStatistic(PRIMARY_STATISTICS[toIndex]);
+    },
+    onSwipedRight: () => {
+      const currentIndex = PRIMARY_STATISTICS.indexOf(mapStatistic);
+      const toIndex =
+        currentIndex < PRIMARY_STATISTICS.length - 1 ? currentIndex + 1 : 0;
+      setMapStatistic(PRIMARY_STATISTICS[toIndex]);
+    },
+  });
+
   return (
     <div
       className={classnames(
@@ -278,12 +294,14 @@ function MapExplorer({
               />
             }
           >
-            <MapVisualizer
-              {...{mapCode, mapView, mapViz}}
-              data={mapData}
-              {...{regionHighlighted, setRegionHighlighted}}
-              statistic={mapStatistic}
-            ></MapVisualizer>
+            <div {...swipeHandlers}>
+              <MapVisualizer
+                {...{mapCode, mapView, mapViz}}
+                data={mapData}
+                {...{regionHighlighted, setRegionHighlighted}}
+                statistic={mapStatistic}
+              ></MapVisualizer>
+            </div>
           </Suspense>
         )}
       </div>


### PR DESCRIPTION
**Description of PR**

This change adds support of swipe gestures on Map Visualizer on home & state page to toggle between various statistics i.e. `Confirmed, Active, Recovered` etc.

**Relevant Issues**  
Fixes #2230

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone


