### PR TITLE
Style: Fixed incorrect timeline position when language selector is open

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1300,6 +1300,27 @@ h6 {
     align-self: center;
   }
 
+  .timeline-container {
+    align-items: center;
+    align-self: unset;
+    display: flex;
+    justify-content: center;
+    position: relative;
+
+    .actions {
+
+      &.timeline {
+        top: 0.25rem;
+
+        @media (max-width: 769px) {
+          .Timeline {
+            margin-left: -3.5rem;
+          }
+        }
+      }
+    }
+  }
+
   .actions {
     display: flex;
     flex-direction: row;

--- a/src/components/ActionsPanel.js
+++ b/src/components/ActionsPanel.js
@@ -95,49 +95,50 @@ const ActionsPanel = ({
 
   return (
     <React.Fragment>
-      <animated.div
-        className="actions"
-        style={{
-          opacity: opacity.interpolate((o) => 1 - o),
-          transform,
-          pointerEvents: isTimelineMode ? 'none' : '',
-        }}
-      >
-        <h5 className="fadeInUp" style={trail[0]}>{`${getTimeFromMilliseconds(
-          lastViewedLog
-        )} IST`}</h5>
-
-        {!showUpdates && (
-          <div className="bell-icon fadeInUp" style={trail[1]}>
-            {Bell}
-            {newUpdate && <div className="indicator"></div>}
-          </div>
-        )}
-
-        {showUpdates && BellOff}
-        <div
-          className="timeline-icon fadeInUp"
-          onClick={handleClick}
-          style={trail[2]}
+      <div className="timeline-container">
+        <animated.div
+          className="actions"
+          style={{
+            opacity: opacity.interpolate((o) => 1 - o),
+            transform,
+            pointerEvents: isTimelineMode ? 'none' : '',
+          }}
         >
-          {TimelineIcon}
-        </div>
-      </animated.div>
+          <h5 className="fadeInUp" style={trail[0]}>{`${getTimeFromMilliseconds(
+            lastViewedLog
+          )} IST`}</h5>
 
-      <animated.div
-        className="actions timeline"
-        style={{
-          opacity,
-          transform: transform.interpolate((t) => `${t} rotateX(180deg)`),
-          pointerEvents: !isTimelineMode ? 'none' : '',
-        }}
-      >
-        {isTimelineMode && (
-          <Suspense fallback={<div />}>
-            <Timeline {...{setIsTimelineMode, setDate, dates}} />
-          </Suspense>
-        )}
-      </animated.div>
+          {!showUpdates && (
+            <div className="bell-icon fadeInUp" style={trail[1]}>
+              {Bell}
+              {newUpdate && <div className="indicator"></div>}
+            </div>
+          )}
+
+          {showUpdates && BellOff}
+          <div
+            className="timeline-icon fadeInUp"
+            onClick={handleClick}
+            style={trail[2]}
+          >
+            {TimelineIcon}
+          </div>
+        </animated.div>
+        <animated.div
+          className="actions timeline"
+          style={{
+            opacity,
+            transform: transform.interpolate((t) => `${t} rotateX(180deg)`),
+            pointerEvents: !isTimelineMode ? 'none' : '',
+          }}
+        >
+          {isTimelineMode && (
+            <Suspense fallback={<div />}>
+              <Timeline {...{setIsTimelineMode, setDate, dates}} />
+            </Suspense>
+          )}
+        </animated.div>
+      </div>
     </React.Fragment>
   );
 };


### PR DESCRIPTION
**Description of PR**
Dates Timeline used to overlap with the language selector. Fixed it by adding a parent div so that absolute positioning of the timeline corresponds to the position of this parent.
Secondly, timeline was not in the center on the phone, fixed that as well. Though still the initial position of the timeline on the phone is little off. But I think that is intended since there are only two dates to be shown initially.

**Relevant Issues**  
Fixes #2225 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![screenshot-localhost_3000-2020 07 10-21_29_12](https://user-images.githubusercontent.com/16023331/87174568-fb2c1380-c2f4-11ea-9f1b-c6d4d7688f50.png)
![screenshot-localhost_3000-2020 07 10-21_30_48](https://user-images.githubusercontent.com/16023331/87174564-fa937d00-c2f4-11ea-89f9-fc7a15fa7193.png)

**Centered Timeline on phone**
![screenshot-localhost_3000-2020 07 10-21_32_44](https://user-images.githubusercontent.com/16023331/87174557-f8c9b980-c2f4-11ea-8fd3-5b10cc81857f.png)
