### PR TITLE
Fix: swipe support for Map Visualizer

### DIFF
--- a/src/components/MapExplorer.js
+++ b/src/components/MapExplorer.js
@@ -172,13 +172,13 @@ function MapExplorer({
   });
 
   const swipeHandlers = useSwipeable({
-    onSwipedRight: () => {
+    onSwipedLeft: () => {
       const currentIndex = PRIMARY_STATISTICS.indexOf(mapStatistic);
       const toIndex =
         currentIndex > 0 ? currentIndex - 1 : PRIMARY_STATISTICS.length - 1;
       setMapStatistic(PRIMARY_STATISTICS[toIndex]);
     },
-    onSwipedLeft: () => {
+    onSwipedRight: () => {
       const currentIndex = PRIMARY_STATISTICS.indexOf(mapStatistic);
       const toIndex =
         currentIndex < PRIMARY_STATISTICS.length - 1 ? currentIndex + 1 : 0;


### PR DESCRIPTION
Related to #2230
Swipe functionality got reversed during a review improvement.
Fixed it now.

**Description of PR**

This fix corrects swipe behavior on map visualizer, i.e. Left swipe go to previous & right swipe go to Next
**Relevant Issues**  
Fixes #2230 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

