### PR TITLE
Added Levitt metric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11373,9 +11373,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "i18next-browser-languagedetector": "^5.0.0",
     "i18next-http-backend": "^1.0.15",
     "immer": "^7.0.5",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "react": "^16.13.1",
     "react-content-loader": "^5.1.0",
     "react-dom": "^16.13.1",

--- a/src/components/TimeseriesExplorer.js
+++ b/src/components/TimeseriesExplorer.js
@@ -189,7 +189,11 @@ function TimeseriesExplorer({
 
         <div className="scale-modes">
           <label className="main">{t('Scale Modes')}</label>
-          <div className="timeseries-mode">
+          <div
+            className={`timeseries-mode ${
+              chartType === 'levitt' ? 'disabled' : ''
+            }`}
+          >
             <label htmlFor="timeseries-mode">{t('Uniform')}</label>
             <input
               id="timeseries-mode"

--- a/src/constants.js
+++ b/src/constants.js
@@ -50,6 +50,7 @@ export const SPRING_CONFIG_NUMBERS = {clamp: true, precision: 1};
 export const TIMESERIES_CHART_TYPES = {
   total: 'Cumulative',
   delta: 'Daily',
+  levitt: 'Levitt',
 };
 
 export const TIMESERIES_LOOKBACKS = {


### PR DESCRIPTION
I've added a new tab (in addition to Cumulative and Daily) which shows a plot of the the [Levitt metric](https://thefederal.com/pandemic-1-mn-in-india/when-will-covid-19-pandemic-end-two-months-or-so-says-levitts-model/) vs time. This involved creating two new functions in src/utils/commonFunctions.js and addition of some code to src/components/Timeseries.js

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
Desktop view:
![Added tab for Levitt metric (desktop view)](https://i.imgur.com/NA1bOKi.png "Added tab for Levitt metric (desktop view)")

Mobile view:
<img alt="Added tab for Levitt metric (mobile view)" src="https://i.imgur.com/OWeX004.jpg" width="480">


