### PR TITLE
Top district text overflow problem solved

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -3329,9 +3329,7 @@ footer {
   .district-bar-left {
     display: flex;
     flex-direction: column;
-    flex-grow: 15rem;
-    flex-shrink: 0;
-    margin-right: 1rem;
+    flex-grow: 1;
   }
 
   .district-bar-right {
@@ -3383,7 +3381,7 @@ footer {
       flex-direction: row;
       height: 2.5rem;
       justify-content: flex-start;
-      margin-right: 1rem;
+      margin-right: 0.5rem;
 
       h2,
       h5 {

--- a/src/App.scss
+++ b/src/App.scss
@@ -3394,7 +3394,6 @@ footer {
 
       h5 {
         display: inline-block !important;
-        flex: 0 1;
         margin-left: 0.5rem;
         margin-top: 0.15rem;
         width: auto !important;

--- a/src/components/State.js
+++ b/src/components/State.js
@@ -108,7 +108,7 @@ function State(props) {
     return styles;
   }, []);
 
-  const lookback = showAllDistricts ? 10 : 6;
+  const lookback = showAllDistricts ? (window.innerWidth >= 540 ? 10 : 8) : 6;
 
   return (
     <React.Fragment>


### PR DESCRIPTION
**Top district text overflow problem solved**

The top district text in the state details overflows/overlaps with the next district text right below it when the text has more than 3 words. And it looks confusing and is attached to the next district text when the length of the text is 3. This problem has been solved by removing `flex: 0 1` in App.scss.


**Relevant Issues**  
Fixes #2210 

**Checklist**

- [ yes] Compiles and passes lint tests
- [ yes ] Properly formatted
- [ yes ] Tested on desktop
- [ yes ] Tested on phone

**Screenshots**

Before:
![before](https://user-images.githubusercontent.com/58804493/88255178-51298f80-ccd5-11ea-99d8-10a8d025e519.jpg)
After:
![after](https://user-images.githubusercontent.com/58804493/88255231-7c13e380-ccd5-11ea-8848-defede0f1265.jpg)

