### PR TITLE
Use sqrt scale for choropleths (see screenshots)

### DIFF
--- a/src/components/MapVisualizer.js
+++ b/src/components/MapVisualizer.js
@@ -22,7 +22,7 @@ import classnames from 'classnames';
 import {max} from 'd3-array';
 import {json} from 'd3-fetch';
 import {geoIdentity, geoPath} from 'd3-geo';
-import {scaleSqrt, scaleSequential} from 'd3-scale';
+import {scaleSqrt, scaleSequentialSqrt} from 'd3-scale';
 // eslint-disable-next-line
 // import worker from 'workerize-loader!../workers/mapVisualizer';
 import {
@@ -108,7 +108,7 @@ function MapVisualizer({
         .clamp(true)
         .nice(3);
     } else {
-      return scaleSequential(
+      return scaleSequentialSqrt(
         [0, Math.max(1, statisticMax)],
         colorInterpolator[statistic]
       ).clamp(true);


### PR DESCRIPTION
**Description of PR**

For choropleth maps, change the scale from sequential to sequentialSqrt.

As the number of cases in a few districts are orders of magnitude above all the others, at an India-level district choropleths have a few dark spots in an ocean of white. It isn't possible to distinguish between the districts that have a statistic near the national median, and those districts for which it is close to zero.

See screenshots.

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

Current:
![Original](https://user-images.githubusercontent.com/210455/88365921-1baaa200-cdba-11ea-97bb-966861f5d5f5.png)

This PR (square root):
![Sqrt](https://user-images.githubusercontent.com/210455/88365923-1cdbcf00-cdba-11ea-9946-2d27102882bd.png)

Alternative considered (log):

![Log](https://user-images.githubusercontent.com/210455/88366321-71cc1500-cdbb-11ea-9f49-cf4f614cb6a7.png)

Unfortunately I think this goes too far, minimizing the difference between hotspot districts and the others. It's very sensitive to the choice of the "bottom" of the scale (0 is not an option), and will need some work to set that to, say, the min or 1-percentile number from the data set. Also makes the legend at the bottom very crowded.