### PR TITLE
Modify css to fix graph overflow issue

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2781,7 +2781,6 @@ input {
     padding: 0.25rem;
     pointer-events: none;
     position: absolute;
-    top: 0.5rem;
 
     h2,
     h5,
@@ -2807,8 +2806,8 @@ input {
       flex-direction: row;
 
       h6 {
-        margin-bottom: 0.1rem;
         margin-left: 0.25rem;
+        margin-top: 0.42rem;
       }
 
       & > * {

--- a/src/components/Timeseries.js
+++ b/src/components/Timeseries.js
@@ -390,8 +390,8 @@ function Timeseries({timeseries, dates, chartType, isUniform, isLog}) {
             >
               {highlightedDate && (
                 <div className={classnames('stats', `is-${statistic}`)}>
-                  <h5 className="title">{t(capitalize(statistic))}</h5>
                   <h5 className="title">
+                    {t(capitalize(statistic))} -{' '}
                     {formatDate(highlightedDate, 'dd MMMM')}
                   </h5>
                   <div className="stats-bottom">


### PR DESCRIPTION
**Description of PR**

A different way of displaying the date and count in chart to avoid overlap

**Relevant Issues**  
Fixes #1650 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![Screen Shot 2020-07-27 at 9 27 13 PM](https://user-images.githubusercontent.com/6641694/88563773-fdf66a80-d04f-11ea-8760-9e275ad09742.png)
![Screen Shot 2020-07-27 at 9 26 56 PM](https://user-images.githubusercontent.com/6641694/88563784-0058c480-d050-11ea-8c13-2945d213704c.png)

Mobile:
![Screen Shot 2020-07-27 at 9 29 00 PM](https://user-images.githubusercontent.com/6641694/88563947-3e55e880-d050-11ea-9468-78968388d26f.png)
![Screen Shot 2020-07-27 at 9 28 38 PM](https://user-images.githubusercontent.com/6641694/88563959-40b84280-d050-11ea-8b9a-fbdefdef18ee.png)

