### PR TITLE
Fix : UI: Unnecessary scrollbar appears when cursor moved on to state…

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -3618,12 +3618,19 @@ footer {
     pointer-events: none;
     right: 0;
     top: 0;
-    transform: translate3d(2rem, 0, 0);
 
     p {
       color: $white !important;
       margin: 0;
     }
+  }
+
+  .upper {
+    transform: translate3d(2rem, 0,  0);
+  }
+
+  .lower {
+    transform: translate3d(2rem, -100%,  0);
   }
 }
 

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -39,6 +39,7 @@ function Row({
   regionHighlighted,
   setRegionHighlighted,
   expandTable,
+  isInUpperHalfOfTable,
 }) {
   const [showDistricts, setShowDistricts] = useState(false);
   const [sortData, setSortData] = useSessionStorage('districtSortData', {
@@ -179,7 +180,7 @@ function Row({
             {t(STATE_NAMES[stateCode]) || districtNameStr}
           </div>
           {data?.meta?.notes && (
-            <Tooltip {...{data: data.meta.notes}}>
+            <Tooltip {...{data: data.meta.notes, isInUpperHalfOfTable}}>
               <InfoIcon size={16} />
             </Tooltip>
           )}

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -279,11 +279,12 @@ function Table({
                   !(stateCode === UNASSIGNED_STATE_CODE && isPerMillion)
               )
               .sort((a, b) => sortingFunction(a, b))
-              .map((stateCode) => {
+              .map((stateCode, index, array) => {
                 return (
                   <Row
                     key={stateCode}
                     data={states[stateCode]}
+                    isInUpperHalfOfTable={index <= array.length / 2}
                     {...{
                       stateCode,
                       isPerMillion,

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -3,7 +3,7 @@ import {TOOLTIP_FADE_IN, TOOLTIP_FADE_OUT} from '../animations';
 import React, {useCallback, useState} from 'react';
 import {useTransition, animated} from 'react-spring';
 
-const Tooltip = ({data, children}) => {
+const Tooltip = ({data, children, isInUpperHalfOfTable = true}) => {
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
 
   const transitions = useTransition(isTooltipVisible, null, {
@@ -32,7 +32,9 @@ const Tooltip = ({data, children}) => {
       {transitions.map(({item, key, props}) =>
         item ? (
           <animated.div key={key} style={props}>
-            <div className="message">
+            <div
+              className={`message ${isInUpperHalfOfTable ? 'upper' : 'lower'}`}
+            >
               <p
                 dangerouslySetInnerHTML={{
                   __html: data.replace(/\n/g, '<br/>'),


### PR DESCRIPTION
… info icon #2179

**Description of PR**

Fixes the UI scroll issue when states at the bottom of the table have a tooltip, which pushes the content and hence the scrollbar.
changes brought
1.  For states in the upper half of the table, the design is the same as that of the current site.
2. For states in the lower half, the popup base will be aligned to the top of the tooltip hence it won't push the content downwards

**Relevant Issues**  
Fixes #2179 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![site-lower](https://user-images.githubusercontent.com/21059591/88941128-473ff780-d2a6-11ea-9499-bff28593461a.png)
![site-upper](https://user-images.githubusercontent.com/21059591/88941132-47d88e00-d2a6-11ea-9b15-feffa4809938.png)

Add relevant screenshots here
