### PR TITLE
Change App.scss links (.About > a) to be green to be more notic…

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -3164,7 +3164,7 @@ footer {
 
   a {
     background: $blue-light;
-    color: $blue;
+    color: $green;
     text-decoration: none;
 
     &:hover {


### PR DESCRIPTION
…eable

**Description of PR**

The links on the about page were hard to identify as links, specifically, the link `list is here`. I changed (suggest really) the color to be something that pops a little bit more to make it easily identifiable that it is a link and something to be clicked on. 

**Relevant Issues**  
Changed in App.scss under .About a {color:$blue} to {color:$green}

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
## Original Coloration:
<img width="609" alt="Original Coloration" src="https://user-images.githubusercontent.com/55409474/90069797-a8ed6200-dca7-11ea-8bf7-23d6befa9186.png">

## New Coloration:
### Phone Coloration -
<img width="844" alt="Phone Color Change" src="https://user-images.githubusercontent.com/55409474/90069804-abe85280-dca7-11ea-969e-823d86145585.png">
### Web browser (chrome) Coloration -
<img width="659" alt="Desktop Color Change" src="https://user-images.githubusercontent.com/55409474/90069806-ac80e900-dca7-11ea-8664-5a7b2db262e3.png">

