### PR TITLE
Fix: District selection by map

### DIFF
--- a/src/components/MapVisualizer.js
+++ b/src/components/MapVisualizer.js
@@ -251,6 +251,10 @@ function MapVisualizer({
       })
       .on('click', (d) => {
         event.stopPropagation();
+        setRegionHighlighted({
+          stateCode: STATE_CODES[d.properties.st_nm],
+          districtName: d.properties.district,
+        });
         const stateCode = STATE_CODES[d.properties.st_nm];
         if (
           onceTouchedRegion.current ||

--- a/src/components/MapVisualizer.js
+++ b/src/components/MapVisualizer.js
@@ -231,12 +231,6 @@ function MapVisualizer({
             .attr('stroke-width', 1.8)
             .attr('stroke-opacity', 0)
             .style('cursor', 'pointer')
-            .on('mouseenter', (d) => {
-              setRegionHighlighted({
-                stateCode: STATE_CODES[d.properties.st_nm],
-                districtName: d.properties.district,
-              });
-            })
             .attr('fill', '#fff0')
             .attr('stroke', '#fff0')
             .call((enter) => {


### PR DESCRIPTION
**Description of PR**

This will fix the issue related to the district selection on the state map.
Here the mouse enter event is removed and the logic is moved to the click event. So now when a region/district has clicked, the info related that particular area is shown.

**Relevant Issues**  
Fixes https://github.com/covid19india/covid19india-react/issues/2319

**Checklist**

- [x] Compiles and passes lint tests
- [x] Tested on desktop
- [x] Properly formatted
- [x] Tested on phone

**Screenshots**

![captured](https://user-images.githubusercontent.com/7911543/91844942-f1c88300-ec75-11ea-897d-bfd6cb04421b.gif)

