### PR TITLE
Feat: Add 6 months option in timeseries

### DIFF
--- a/src/components/TimeseriesExplorer.js
+++ b/src/components/TimeseriesExplorer.js
@@ -130,19 +130,19 @@ function TimeseriesExplorer({
     const lastDate = pastDates[pastDates.length - 1];
     if (lookback === TIMESERIES_LOOKBACKS.BEGINNING) {
       return pastDates;
-    }
-
-    let cutOffDateLower;
-    if (lookback === TIMESERIES_LOOKBACKS.MONTH) {
-      cutOffDateLower = formatISO(sub(parseIndiaDate(lastDate), {months: 1}), {
+    } else {
+      let lookbackMonths, cutOffDateLower;
+      switch(lookback) {
+        case TIMESERIES_LOOKBACKS.SIX_MONTHS: lookbackMonths = 6; break;
+        case TIMESERIES_LOOKBACKS.THREE_MONTHS: lookbackMonths = 3; break;
+        case TIMESERIES_LOOKBACKS.MONTH: ; // default value = 1
+        default: lookbackMonths = 1; break
+      }
+      cutOffDateLower = formatISO(sub(parseIndiaDate(lastDate), {months: lookbackMonths}), {
         representation: 'date',
       });
-    } else if (lookback === TIMESERIES_LOOKBACKS.THREE_MONTHS) {
-      cutOffDateLower = formatISO(sub(parseIndiaDate(lastDate), {months: 3}), {
-        representation: 'date',
-      });
+      return pastDates.filter((date) => date >= cutOffDateLower);
     }
-    return pastDates.filter((date) => date >= cutOffDateLower);
   }, [selectedTimeseries, timelineDate, lookback]);
 
   const handleChange = useCallback(

--- a/src/constants.js
+++ b/src/constants.js
@@ -160,6 +160,7 @@ export const TIMESERIES_CHART_TYPES = {
 
 export const TIMESERIES_LOOKBACKS = {
   BEGINNING: 'Beginning',
+  SIX_MONTHS: '6 Months',
   THREE_MONTHS: '3 Months',
   MONTH: '1 Month',
 };


### PR DESCRIPTION
Add 6 months option in timeseries

I use the website regularly and felt the need for a 6 months button in timeseries.

**Checklist**
- [Y] Compiles and passes lint tests
- [Y] Properly formatted
- [Y] Tested on desktop
- [Y] Tested on phone

**Screenshots**

<img width="350" alt="image" src="https://user-images.githubusercontent.com/9139017/95026803-9729a900-06b1-11eb-9ccf-8358cc37ea76.png">
