### PR TITLE
Fix: Text and chart bars are overlapping in Daily growth chart under Spread Trends

### DIFF
--- a/src/components/Timeseries.js
+++ b/src/components/Timeseries.js
@@ -26,7 +26,7 @@ import React, {useCallback, useEffect, useRef, useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 
 // Chart margins
-const margin = {top: 15, right: 35, bottom: 25, left: 25};
+const margin = {top: 45, right: 35, bottom: 25, left: 45};
 
 function Timeseries({timeseries, dates, chartType, isUniform, isLog}) {
   const {t} = useTranslation();
@@ -381,6 +381,16 @@ function Timeseries({timeseries, dates, chartType, isUniform, isLog}) {
               ref={wrapperRef}
               style={trail[index]}
             >
+              <svg
+                ref={(element) => {
+                  refs.current[index] = element;
+                }}
+                preserveAspectRatio="xMidYMid meet"
+              >
+                <g className="x-axis" />
+                <g className="x-axis2" />
+                <g className="y-axis" />
+              </svg>
               {highlightedDate && (
                 <div className={classnames('stats', `is-${statistic}`)}>
                   <h5 className="title">
@@ -413,16 +423,6 @@ function Timeseries({timeseries, dates, chartType, isUniform, isLog}) {
                   </div>
                 </div>
               )}
-              <svg
-                ref={(element) => {
-                  refs.current[index] = element;
-                }}
-                preserveAspectRatio="xMidYMid meet"
-              >
-                <g className="x-axis" />
-                <g className="x-axis2" />
-                <g className="y-axis" />
-              </svg>
             </div>
           );
         })}


### PR DESCRIPTION
Fix: Text and chart bars are overlapping in Daily growth chart under Spread Trends

Fixed the merging of chart bars and statistical data in Daily Growth charts. Increased the margins of the chart boxes to fix the overlap.

**Relevant Issues**  
Fixes #2368  

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**

![covid19screenshot](https://user-images.githubusercontent.com/30225157/95991427-9b587380-0de1-11eb-88aa-cc4c1de416c0.jpg)

