### PR TITLE
Doc: Changed Title to remove "- covid19india.org"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <meta name="theme-color" content="#ffffff" />
 
     <!-- Primary Meta Tags -->
-    <title>Coronavirus Outbreak in India - covid19india.org</title>
+    <title>Coronavirus Outbreak in India</title>
     <meta
       name="title"
       content="Coronavirus Outbreak in India: Latest Map and Case Count"


### PR DESCRIPTION
The title of the webpage - "Coronavirus Outbreak in India - covid19india.org" is changed in an attempt to remove the string - " - covid19india.org" that does not show up on the computer browser. 

I am proposing deleting the string " - covid19india.org" from the index.html code.

**Checklist**

- [ ] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [ ] Tested on phone

**Screenshots**

Screenshot from Google Chrome:-
![image](https://user-images.githubusercontent.com/72481455/103392001-d2d5e280-4ae9-11eb-8eef-4e97ece46ff3.png)
Text - " - covid19india.org" does not show up here as you can see.

PS:
This is my first pull request. I have reviewed the 'contributing guidelines' and I am attempting to follow them as much as possible. In case I made a mistake please accept my apologies. I am still learning.