### PR TITLE
removed the scroll bar below the "home-left" div

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -249,7 +249,7 @@ h6 {
   .home-right {
     display: flex;
     flex-direction: column;
-    width: 34rem;
+    width: 42rem;
   }
 
   .home-left {


### PR DESCRIPTION
to removed the scroll bar below the "home-left", changed the "home-left" width to 42 rem as same for the "home-right" div

**Description of PR**

a scroll bar below the "home-left" div is showing in the desktop full-screen view. not looking good. has been fixed here.

**Checklist**

- [ yes ] Compiles and passes lint tests
- [ yes ] Properly formatted
- [ yes ] Tested on desktop
- [ yes ] Tested on phone

**Screenshots**
Before: https://drive.google.com/file/d/1Fs2TI3v8BAwqcUBxQOd9t8i4cv4ZLjk5/view?usp=sharing
After: https://drive.google.com/file/d/1DSdViqzH1T-s_vs8CY8QcmvTxdAxizUt/view?usp=sharing
