### PR TITLE
Style: Fix overflow

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4252,7 +4252,7 @@ footer {
   .timeline,
   .table-top,
   .LanguageSwitcher {
-    width: calc(100% - 2rem);
+    width: calc(100% - 3rem);
   }
 
   .Home,


### PR DESCRIPTION
**Description of PR**

```.map-container``` overflow in table view

**Relevant Issues**

Changed in App.scss under 
```SCSS
@media (max-width: 769px) .map-container {width: calc(100% - 2rem);}
```
to 
```SCSS
{width: calc(100% - 3rem);}
```

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![1](https://user-images.githubusercontent.com/26327320/114560111-00562e80-9c8a-11eb-94b1-bad6cd945be7.PNG)
![2](https://user-images.githubusercontent.com/26327320/114560123-03e9b580-9c8a-11eb-8615-62be708e2ac4.PNG)

