### PR TITLE
Fixes the weird placeholder strings appearing when language was changed

### DIFF
--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -10,7 +10,7 @@ import {
 import produce from 'immer';
 import {memo, useState, useEffect, useMemo, useCallback, useRef} from 'react';
 import * as Icon from 'react-feather';
-import {useTranslation} from 'react-i18next';
+import {useTranslation, getInitialProps} from 'react-i18next';
 import {Link} from 'react-router-dom';
 import {useDebounce, useKeyPressEvent, useUpdateEffect} from 'react-use';
 
@@ -42,6 +42,7 @@ const stateSuggestions = [
 function Search() {
   const [searchValue, setSearchValue] = useState('');
   const [expand, setExpand] = useState(false);
+  const [language, setLanguage] = useState(getInitialProps().initialLanguage);
   const [results, setResults] = useState([]);
   const searchInput = useRef(null);
   const {t} = useTranslation();
@@ -174,6 +175,10 @@ function Search() {
         target.textContent = '';
         return true;
       }
+      if (language != getInitialProps().initialLanguage) {
+        setLanguage(getInitialProps().initialLanguage);
+        return true;
+      }
       const text = t(suggestions[index]);
       const placeholder = target.textContent;
       target.classList.remove('disappear');
@@ -186,7 +191,7 @@ function Search() {
       }
       callback();
     },
-    [expand, t]
+    [language, expand, t]
   );
 
   const clearPlaceholder = useCallback((target, callback) => {
@@ -208,7 +213,10 @@ function Search() {
         target.textContent = '';
         return true;
       }
-
+      if (language != getInitialProps().initialLanguage) {
+        setLanguage(getInitialProps().initialLanguage);
+        return true;
+      }
       fillPlaceholder(target, index, 0, function () {
         setTimeout(function () {
           clearPlaceholder(target, function () {
@@ -217,7 +225,7 @@ function Search() {
         }, 2000);
       });
     },
-    [clearPlaceholder, expand, fillPlaceholder]
+    [language, clearPlaceholder, expand, fillPlaceholder]
   );
 
   useEffect(() => {


### PR DESCRIPTION
Fixes #2507 

A brief description of what changes your PR introduces. The better this description, the quicker we can review, exchange feedback, and merge!
After changing language the placeholder was displaying weird strings and not the cities suggestion you added it was happening because of useCallback function that starts running and do not terminate the priveous instance of useCallback I added language dependency to useCallback and function will terminate whenever the language state changes.

Fixes #2507 

✔️ Compiles and passes lint tests
✔️ Properly formatted
✔️ Tested on desktop
✔️ Tested on phone

Before Fixing Screenshot : 

![initially](https://user-images.githubusercontent.com/49324368/123940567-f0133d00-d9b6-11eb-95d5-f61480d2a8ec.png)
Initially wrong strings 


After Fixing Screenshots

![now](https://user-images.githubusercontent.com/49324368/123940671-0620fd80-d9b7-11eb-8920-100e79b7b794.PNG)

![nowtwo](https://user-images.githubusercontent.com/49324368/123940740-189b3700-d9b7-11eb-88d3-ed5f48f40e4d.PNG)
:




