### PR TITLE
Direct dial helpline numbers feature.

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -21,6 +21,25 @@ function Footer() {
 
       <h5>{t('We stand with everyone fighting on the frontlines')}</h5>
 
+      <div>
+
+      <h3>Covid-19 Helpline:
+      
+<a href="tel:1075" >|Health Ministry| </a>
+
+<a href="tel:1098"> | Child Support | </a>
+<a href="tel:08046110007"> | Mental Health | </a>
+<a href="tel:14567"> | Senior Citizens | </a>
+<a href="tel:14443"> | Counselling | </a>
+<a href="tel:9013151515"> | MyGov Whatsapp Helpdesk | </a>
+
+</h3>
+
+      </div>
+      
+      
+
+
       <div className="links">
         <a
           href="https://github.com/covid19india/covid19india-react"


### PR DESCRIPTION
Added direct dial helpline numbers feature. #2549  

Any user can call the helpline numbers with a single click on the screen and seek all kinds of covid-19 related help. Clicking on any of the given topics will redirect the user to the phone dialer (smartphone) and prompt a call notification (Desktop).

No issues.

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**


![Screenshot (48)](https://user-images.githubusercontent.com/47190861/131170019-e3fa2f1e-96c4-4ac0-b5e7-d21ca1312191.png)

