### PR TITLE
Changed the table header to sticky headers.

### DIFF
--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -243,6 +243,43 @@ function Table({
   useKeyPressEvent('?', () => {
     setIsInfoVisible(!isInfoVisible);
   });
+  
+  useEffect(() =>{
+    let table = document.querySelector('.table-container>.table');
+    let headers = document.querySelectorAll('.table-container>.table>.row.heading:first-child>.cell');
+    
+    // Set config values, set the special z indices for the header divs
+    const stickBottomLimit = 150;
+    const firstHeaderZ = 140;
+    const otherHeaderZ = 120;
+    headers.forEach((el, index)=>{
+        el.style.zIndex = index==0 ? firstHeaderZ : otherHeaderZ;
+    });
+
+    // Build the handler that makes headers stick
+    const handleScroll = ()=>{
+        const rect = table.getBoundingClientRect();
+        let offset = 0;
+        if (rect.top < 0) {
+            offset = Math.min(-rect.top, rect.height-stickBottomLimit);
+        }
+        headers.forEach((el)=>{
+            el.style.transform = 'translateY('+offset+'px)';
+        });
+    };
+
+    // Build debounced scroll listener
+    let ticking = false;
+    document.addEventListener('scroll', (e)=>{
+        if (!ticking) {
+            window.requestAnimationFrame(()=>{
+                handleScroll();
+                ticking = false;
+            });
+            ticking = true;
+        }
+    });
+  })
 
   return (
     <div className="Table">


### PR DESCRIPTION
**Description of PR**

I used a small JS script to detect scroll and stick the elements with header property to the top of the screen when the scroll reaches the top. 

**Relevant Issues**  
Fixes #2434 

**Checklist**

- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Screenshots**
![image](https://user-images.githubusercontent.com/67572440/131257193-3eeef054-5e83-4e85-83dc-c27e21c3ddf6.png)

