### PR TITLE
Move `overflow-x: hidden` from `html` to `body` fixes #2056

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -79,7 +79,6 @@ $dark-m-purple-light: #40008050;
 }
 
 html {
-  overflow-x: hidden;
   width: 100vw;
 }
 
@@ -87,6 +86,7 @@ body {
   -webkit-tap-highlight-color: transparent;
   -webkit-touch-callout: none;
   margin: 0;
+  overflow-x: hidden;
   padding: 0;
 }
 


### PR DESCRIPTION
**Relevant Issues** <br>
Fixes #2056

**Checklist**
- [x] Compiles and passes lint tests
- [x] Properly formatted
- [x] Tested on desktop
- [x] Tested on phone

**Description of PR**

Due to `overflow-x: hidden` set on `html`, `overflow: hidden` applied on `body` got rejected. <br>
So moved the `overflow-x: hidden` to body from html [ref](https://stackoverflow.com/a/41507857/10066692)

Before                |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/35309821/132097239-7652732c-1dc0-436c-9555-134a19d3c1ad.png)  |  ![image](https://user-images.githubusercontent.com/35309821/132097290-349be389-454c-456c-942a-2bef6530f6b2.png)
